### PR TITLE
feat(android): Request permission screen improvement

### DIFF
--- a/androidApp/src/main/java/org/gdglille/devfest/android/screens/scanner/FeatureThatRequiresCameraPermission.kt
+++ b/androidApp/src/main/java/org/gdglille/devfest/android/screens/scanner/FeatureThatRequiresCameraPermission.kt
@@ -1,21 +1,19 @@
 package org.gdglille.devfest.android.screens.scanner
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.*
 import androidx.compose.material.Button
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.OutlinedButton
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.google.accompanist.permissions.ExperimentalPermissionsApi
-import com.google.accompanist.permissions.PermissionStatus
-import com.google.accompanist.permissions.rememberPermissionState
-import com.google.accompanist.permissions.shouldShowRationale
+import com.google.accompanist.permissions.*
 import org.gdglille.devfest.android.R
+import org.gdglille.devfest.android.theme.Conferences4HallTheme
 
 @OptIn(ExperimentalPermissionsApi::class)
 @Composable
@@ -24,34 +22,98 @@ fun FeatureThatRequiresCameraPermission(
     onRefusePermissionClicked: () -> Unit,
     content: @Composable () -> Unit
 ) {
+    val paddingModifier = Modifier.padding(24.dp)
     val cameraPermissionState = rememberPermissionState(android.Manifest.permission.CAMERA)
     when (cameraPermissionState.status) {
         is PermissionStatus.Denied -> {
             if (cameraPermissionState.status.shouldShowRationale) {
-                Column {
-                    Text(text = stringResource(id = R.string.text_camera_permission_deny))
-                    Spacer(modifier = Modifier.height(8.dp))
-                    Button(onClick = navigateToSettingsScreen) {
-                        Text(text = stringResource(id = R.string.action_system_settings))
-                    }
-                }
+                FeatureThatRequiresCameraPermissionDenied(
+                    modifier = paddingModifier,
+                    navigateToSettingsScreen = navigateToSettingsScreen
+                )
             } else {
-                Column {
-                    Text(text = stringResource(id = R.string.text_camera_permission_explaination))
-                    Spacer(modifier = Modifier.height(8.dp))
-                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                        Button(onClick = { cameraPermissionState.launchPermissionRequest() }) {
-                            Text(text = stringResource(id = R.string.action_submit_accept))
-                        }
-                        Button(onClick = onRefusePermissionClicked) {
-                            Text(text = stringResource(id = R.string.action_submit_deny))
-                        }
-                    }
-                }
+                FeatureThatRequiresCameraPermissionRequested(
+                    modifier = paddingModifier,
+                    onAcceptPermissionClicked = { cameraPermissionState.launchPermissionRequest() },
+                    onRefusePermissionClicked = onRefusePermissionClicked
+                )
             }
         }
         is PermissionStatus.Granted -> {
             content()
         }
+    }
+}
+
+@OptIn(ExperimentalPermissionsApi::class)
+@Composable
+private fun FeatureThatRequiresCameraPermissionRequested(
+    modifier: Modifier = Modifier,
+    onAcceptPermissionClicked: () -> Unit,
+    onRefusePermissionClicked: () -> Unit
+) {
+    Column(
+        modifier = modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            style = MaterialTheme.typography.h6,
+            text = stringResource(id = R.string.text_permission)
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(text = stringResource(id = R.string.text_camera_permission_explaination))
+        Spacer(modifier = Modifier.height(12.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            OutlinedButton(onClick = onRefusePermissionClicked) {
+                Text(text = stringResource(id = R.string.action_submit_later))
+            }
+            Button(onClick = onAcceptPermissionClicked) {
+                Text(text = stringResource(id = R.string.action_submit_accept))
+            }
+        }
+    }
+}
+
+@Composable
+private fun FeatureThatRequiresCameraPermissionDenied(
+    modifier: Modifier = Modifier,
+    navigateToSettingsScreen: () -> Unit
+) {
+    Column(
+        modifier = modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            style = MaterialTheme.typography.h6,
+            text = stringResource(id = R.string.text_permission)
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(text = stringResource(id = R.string.text_camera_permission_deny))
+        Spacer(modifier = Modifier.height(12.dp))
+        Button(onClick = navigateToSettingsScreen) {
+            Text(text = stringResource(id = R.string.action_system_settings))
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun FeatureThatRequiresCameraPermissionRequestedPreview() {
+    Conferences4HallTheme {
+        FeatureThatRequiresCameraPermissionRequested(
+            onAcceptPermissionClicked = {},
+            onRefusePermissionClicked = {})
+    }
+}
+
+@Preview
+@Composable
+private fun FeatureThatRequiresCameraPermissionDeniedPreview() {
+    Conferences4HallTheme {
+        FeatureThatRequiresCameraPermissionDenied(
+            navigateToSettingsScreen = {}
+        )
     }
 }

--- a/ui/src/main/res/values-fr/strings.xml
+++ b/ui/src/main/res/values-fr/strings.xml
@@ -22,6 +22,7 @@
     <string name="text_level_intermediate">Intermédiaire</string>
     <string name="text_level_beginner">Débutant</string>
     <string name="text_openfeedback_not_started">Vous serez en mesure de donner un feedback quand la session aura démarrée !</string>
+    <string name="text_permission">Permission requise</string>
     <string name="text_camera_permission_explaination">La caméra est importante pour scanner des Qrcode. Pense à accepter la permission.</string>
     <string name="text_camera_permission_deny">La permission pour la caméra a été refusée. Pense à donner l\'accès via les paramètres systèmes.</string>
     <string name="text_report_subject">Report aux organisateurs depuis l\'app Devfest Lille</string>
@@ -46,8 +47,9 @@
     <string name="action_favorites_remove">Retire la session de tes favoris</string>
     <string name="action_favorites_add">Ajoute la session dans tes favoris</string>
     <string name="action_generate_qrcode">Générer ton Qrcode</string>
-    <string name="action_submit_accept">Ok</string>
+    <string name="action_submit_accept">OK</string>
     <string name="action_submit_deny">Non</string>
+    <string name="action_submit_later">Plus tard</string>
     <string name="action_networking_delete">Supprimer le profile</string>
 
     <string name="input_email">Ton adresse email*</string>

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -22,6 +22,7 @@
     <string name="text_level_intermediate">Intermediate</string>
     <string name="text_level_beginner">Beginner</string>
     <string name="text_openfeedback_not_started">You\'ll be able to give feedback when the session has started!</string>
+    <string name="text_permission">Permission required</string>
     <string name="text_camera_permission_explaination">The camera is important to scan QR code. Please grant the permission.</string>
     <string name="text_camera_permission_deny">Camera permission denied. Please, grant us access on the Settings screen.</string>
     <string name="text_report_subject">Report to organizers from Devfest Lille App</string>
@@ -46,8 +47,9 @@
     <string name="action_favorites_remove">Remove schedule from favorites</string>
     <string name="action_favorites_add">Add schedule in favorite</string>
     <string name="action_generate_qrcode">Generate your QR code</string>
-    <string name="action_submit_accept">Ok</string>
+    <string name="action_submit_accept">OK</string>
     <string name="action_submit_deny">No</string>
+    <string name="action_submit_later">Later</string>
     <string name="action_networking_delete">Delete the profile</string>
 
     <string name="input_email">Your email address*</string>


### PR DESCRIPTION
- Small improvement of request permission screens : outlined button, wording, spacing, margin, …
- Extract composable to enable Previews

Result without external margin:
![image](https://user-images.githubusercontent.com/4005409/172378964-e5411f39-8b91-4aa4-a4cf-c74106e00a4e.png)

