### PR TITLE
Attach speakers to partners via partners-connect webhook

### DIFF
--- a/backend/src/main/java/com/paligot/confily/backend/internals/infrastructure/exposed/DatabaseFactory.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/internals/infrastructure/exposed/DatabaseFactory.kt
@@ -21,6 +21,7 @@ import com.paligot.confily.backend.map.infrastructure.exposed.MapsTable
 import com.paligot.confily.backend.menus.infrastructure.exposed.LunchMenusTable
 import com.paligot.confily.backend.partners.infrastructure.exposed.JobsTable
 import com.paligot.confily.backend.partners.infrastructure.exposed.PartnerSocialsTable
+import com.paligot.confily.backend.partners.infrastructure.exposed.PartnerSpeakersTable
 import com.paligot.confily.backend.partners.infrastructure.exposed.PartnerSponsorshipsTable
 import com.paligot.confily.backend.partners.infrastructure.exposed.PartnersTable
 import com.paligot.confily.backend.partners.infrastructure.exposed.SponsoringTypesTable
@@ -71,6 +72,7 @@ object DatabaseFactory {
         TeamSocialsTable,
         SpeakerSocialsTable,
         PartnerSocialsTable,
+        PartnerSpeakersTable,
         JobsTable,
         ActivitiesTable,
         SchedulesTable,

--- a/backend/src/main/java/com/paligot/confily/backend/partners/infrastructure/exposed/PartnerSpeakerEntity.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/partners/infrastructure/exposed/PartnerSpeakerEntity.kt
@@ -1,0 +1,22 @@
+package com.paligot.confily.backend.partners.infrastructure.exposed
+
+import com.paligot.confily.backend.speakers.infrastructure.exposed.SpeakerEntity
+import org.jetbrains.exposed.dao.UUIDEntity
+import org.jetbrains.exposed.dao.UUIDEntityClass
+import org.jetbrains.exposed.dao.id.EntityID
+import java.util.UUID
+
+class PartnerSpeakerEntity(id: EntityID<UUID>) : UUIDEntity(id) {
+    companion object : UUIDEntityClass<PartnerSpeakerEntity>(PartnerSpeakersTable) {
+        fun findByPartner(partnerId: UUID): List<PartnerSpeakerEntity> = find {
+            PartnerSpeakersTable.partnerId eq partnerId
+        }.toList()
+
+        fun findBySpeaker(speakerId: UUID): List<PartnerSpeakerEntity> = find {
+            PartnerSpeakersTable.speakerId eq speakerId
+        }.toList()
+    }
+
+    var partner by PartnerEntity referencedOn PartnerSpeakersTable.partnerId
+    var speaker by SpeakerEntity referencedOn PartnerSpeakersTable.speakerId
+}

--- a/backend/src/main/java/com/paligot/confily/backend/partners/infrastructure/exposed/PartnerSpeakersTable.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/partners/infrastructure/exposed/PartnerSpeakersTable.kt
@@ -1,0 +1,26 @@
+package com.paligot.confily.backend.partners.infrastructure.exposed
+
+import com.paligot.confily.backend.speakers.infrastructure.exposed.SpeakersTable
+import org.jetbrains.exposed.dao.id.UUIDTable
+import org.jetbrains.exposed.sql.ReferenceOption
+import org.jetbrains.exposed.sql.selectAll
+import java.util.UUID
+
+object PartnerSpeakersTable : UUIDTable("partner_speakers") {
+    val partnerId = reference("partner_id", PartnersTable, onDelete = ReferenceOption.CASCADE)
+    val speakerId = reference("speaker_id", SpeakersTable, onDelete = ReferenceOption.CASCADE)
+
+    init {
+        index(isUnique = false, partnerId)
+        index(isUnique = false, speakerId)
+        uniqueIndex(partnerId, speakerId)
+    }
+
+    fun speakerIds(partnerId: UUID): List<UUID> = this.selectAll()
+        .where { PartnerSpeakersTable.partnerId eq partnerId }
+        .map { it[speakerId].value }
+
+    fun partnerIds(speakerId: UUID): List<UUID> = this.selectAll()
+        .where { PartnerSpeakersTable.speakerId eq speakerId }
+        .map { it[partnerId].value }
+}

--- a/backend/src/main/java/com/paligot/confily/backend/partners/infrastructure/exposed/PartnersMappers.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/partners/infrastructure/exposed/PartnersMappers.kt
@@ -7,6 +7,7 @@ import com.paligot.confily.models.PartnerMediaPngs
 import com.paligot.confily.models.PartnerV2
 import com.paligot.confily.models.PartnerV3
 import com.paligot.confily.models.SocialType
+import com.paligot.confily.backend.speakers.infrastructure.exposed.toModel as toSpeakerModel
 
 fun PartnerEntity.toModelV1(): Partner {
     return Partner(
@@ -47,7 +48,8 @@ fun PartnerEntity.toModelV2(): PartnerV2 {
         linkedinUrl = socials.find { it.type == SocialType.LinkedIn }?.url,
         linkedinMessage = null,
         address = this.address?.toModel(),
-        jobs = jobs.map { job -> job.toModel(this.name) }
+        jobs = jobs.map { job -> job.toModel(this.name) },
+        speakers = PartnerSpeakerEntity.findByPartner(partnerId).map { it.speaker.toSpeakerModel() }
     )
 }
 
@@ -77,6 +79,7 @@ fun PartnerEntity.toModelV3(): PartnerV3 {
         types = PartnerSponsorshipsTable.sponsoringTypeNamesByPartner(partnerUuid),
         address = this.address?.toModel(),
         socials = PartnerSocialsTable.socials(partnerUuid),
-        jobs = jobs.map { job -> job.toModel(this.name) }
+        jobs = jobs.map { job -> job.toModel(this.name) },
+        speakers = PartnerSpeakerEntity.findByPartner(partnerUuid).map { it.speaker.toSpeakerModel() }
     )
 }

--- a/backend/src/main/java/com/paligot/confily/backend/speakers/infrastructure/exposed/SpeakerMappers.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/speakers/infrastructure/exposed/SpeakerMappers.kt
@@ -1,5 +1,7 @@
 package com.paligot.confily.backend.speakers.infrastructure.exposed
 
+import com.paligot.confily.backend.partners.infrastructure.exposed.PartnerSpeakerEntity
+import com.paligot.confily.models.PartnerItem
 import com.paligot.confily.models.Speaker
 
 fun SpeakerEntity.toModel(): Speaker = Speaker(
@@ -10,5 +12,12 @@ fun SpeakerEntity.toModel(): Speaker = Speaker(
     jobTitle = this.jobTitle,
     company = this.company,
     photoUrl = this.photoUrl ?: "",
-    socials = SpeakerSocialsTable.socials(id.value)
+    socials = SpeakerSocialsTable.socials(id.value),
+    partners = PartnerSpeakerEntity.findBySpeaker(id.value).map { ps ->
+        PartnerItem(
+            id = ps.partner.id.value.toString(),
+            name = ps.partner.name,
+            logoUrl = ps.partner.mediaSvg ?: ""
+        )
+    }
 )

--- a/backend/src/main/java/com/paligot/confily/backend/third/parties/partnersconnect/application/PartnersConnectRepositoryExposed.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/third/parties/partnersconnect/application/PartnersConnectRepositoryExposed.kt
@@ -13,8 +13,11 @@ import com.paligot.confily.backend.internals.infrastructure.exposed.SocialsTable
 import com.paligot.confily.backend.partners.infrastructure.exposed.JobsTable
 import com.paligot.confily.backend.partners.infrastructure.exposed.PartnerEntity
 import com.paligot.confily.backend.partners.infrastructure.exposed.PartnerSocialsTable
+import com.paligot.confily.backend.partners.infrastructure.exposed.PartnerSpeakerEntity
+import com.paligot.confily.backend.partners.infrastructure.exposed.PartnerSpeakersTable
 import com.paligot.confily.backend.partners.infrastructure.exposed.PartnerSponsorshipsTable
 import com.paligot.confily.backend.partners.infrastructure.exposed.SponsoringTypeEntity
+import com.paligot.confily.backend.speakers.infrastructure.exposed.SpeakerEntity
 import com.paligot.confily.backend.third.parties.partnersconnect.domain.PartnersConnectRepository
 import com.paligot.confily.backend.third.parties.partnersconnect.infrastructure.provider.InvoiceStatus
 import com.paligot.confily.backend.third.parties.partnersconnect.infrastructure.provider.PartnersConnectWebhookPayload
@@ -68,6 +71,7 @@ class PartnersConnectRepositoryExposed(
             upsertSocials(partner, event, payload)
             upsertJobs(partner, payload)
             upsertActivities(partner, event, payload)
+            upsertSpeakers(partner, eventUuid, payload)
             partner.id.value.toString()
         }
     }
@@ -195,6 +199,27 @@ class PartnersConnectRepositoryExposed(
                     this.externalId = activity.id
                     this.externalProvider = IntegrationProvider.PARTNERSCONNECT
                 }
+        }
+    }
+
+    private fun upsertSpeakers(
+        partner: PartnerEntity,
+        eventId: UUID,
+        payload: PartnersConnectWebhookPayload
+    ) {
+        PartnerSpeakersTable.deleteWhere { PartnerSpeakersTable.partnerId eq partner.id.value }
+        val openPlannerSpeakers = payload.speakers
+            .filter { it.source.equals(IntegrationProvider.OPENPLANNER.name, ignoreCase = true) }
+        if (openPlannerSpeakers.isEmpty()) return
+        SpeakerEntity.findByExternalIds(
+            eventId = eventId,
+            speakerIds = openPlannerSpeakers.map { it.externalId },
+            provider = IntegrationProvider.OPENPLANNER
+        ).forEach { speaker ->
+            PartnerSpeakerEntity.new {
+                this.partner = partner
+                this.speaker = speaker
+            }
         }
     }
 }

--- a/backend/src/main/java/com/paligot/confily/backend/third/parties/partnersconnect/infrastructure/provider/WebhookPayload.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/third/parties/partnersconnect/infrastructure/provider/WebhookPayload.kt
@@ -12,6 +12,7 @@ data class PartnersConnectWebhookPayload(
     val event: EventSummary,
     val jobs: List<JobOffer>,
     val activities: List<BoothActivity>,
+    val speakers: List<WebhookSpeaker> = emptyList(),
     val timestamp: String
 )
 
@@ -149,4 +150,20 @@ data class BoothActivity(
     val endTime: LocalDateTime?,
     @SerialName("created_at")
     val createdAt: LocalDateTime
+)
+
+@Serializable
+data class WebhookSpeaker(
+    val id: String,
+    val name: String,
+    val biography: String? = null,
+    @SerialName("job_title")
+    val jobTitle: String? = null,
+    @SerialName("photo_url")
+    val photoUrl: String? = null,
+    val pronouns: String? = null,
+    val company: String? = null,
+    @SerialName("external_id")
+    val externalId: String,
+    val source: String
 )

--- a/shared/models/src/commonMain/kotlin/com/paligot/confily/models/Partner.kt
+++ b/shared/models/src/commonMain/kotlin/com/paligot/confily/models/Partner.kt
@@ -13,6 +13,14 @@ data class Partner(
 )
 
 @Serializable
+data class PartnerItem(
+    val id: String,
+    val name: String,
+    @SerialName("logo_url")
+    val logoUrl: String
+)
+
+@Serializable
 data class PartnerMediaPngs(
     val _250: String,
     val _500: String,
@@ -47,7 +55,8 @@ data class PartnerV2(
     @SerialName("linkedin_message")
     val linkedinMessage: String?,
     val address: Address?,
-    val jobs: List<Job> = emptyList()
+    val jobs: List<Job> = emptyList(),
+    val speakers: List<Speaker> = emptyList()
 )
 
 @Serializable
@@ -61,5 +70,6 @@ data class PartnerV3(
     val address: Address?,
     val types: List<String>,
     val socials: List<SocialItem> = emptyList(),
-    val jobs: List<Job> = emptyList()
+    val jobs: List<Job> = emptyList(),
+    val speakers: List<Speaker> = emptyList()
 )

--- a/shared/models/src/commonMain/kotlin/com/paligot/confily/models/Speaker.kt
+++ b/shared/models/src/commonMain/kotlin/com/paligot/confily/models/Speaker.kt
@@ -16,6 +16,7 @@ data class Speaker(
     @SerialName("photo_url")
     val photoUrl: String,
     val socials: List<SocialItem>,
+    val partners: List<PartnerItem> = emptyList(),
     @Deprecated("use socials property instead")
     val website: String? = null,
     @Deprecated("use socials property instead")


### PR DESCRIPTION
## What

Partners-connect now returns associated speakers in its webhook payload. This PR wires that data into the backend so that:

- Each partner exposes its attached speakers in `PartnerV2` and `PartnerV3`
- Each speaker exposes a lightweight `PartnerItem` list in the agenda/speaker endpoints

## How

A new `partner_speakers` join table backed by `PartnerSpeakerEntity` stores the many-to-many relation between partners and speakers. On each webhook call, `upsertSpeakers` resolves incoming speakers (filtered to `source == "openplanner"`) against existing speaker records by `external_id`, then replaces the current relations for that partner.

The new `PartnerItem` shared model (id, name, logo_url) is used for the speaker → partner direction to avoid full nesting. The `PartnerSpeakerEntity` follows the same `UUIDEntity` pattern used across the codebase, keeping mapper code clean via direct entity navigation (`it.speaker.toModel()`, `ps.partner`).