### PR TITLE
Add OpenFeedback integration to return feedback URLs per session

### DIFF
--- a/backend/src/main/java/com/paligot/confily/backend/events/application/EventRepositoryExposed.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/events/application/EventRepositoryExposed.kt
@@ -13,6 +13,8 @@ import com.paligot.confily.backend.events.infrastructure.exposed.toEventItemList
 import com.paligot.confily.backend.integrations.domain.IntegrationProvider
 import com.paligot.confily.backend.integrations.domain.IntegrationUsage
 import com.paligot.confily.backend.integrations.infrastructure.exposed.IntegrationEntity
+import com.paligot.confily.backend.integrations.infrastructure.exposed.OpenFeedbackIntegrationsTable
+import com.paligot.confily.backend.integrations.infrastructure.exposed.get
 import com.paligot.confily.backend.internals.helpers.slug
 import com.paligot.confily.backend.map.infrastructure.exposed.MapEntity
 import com.paligot.confily.backend.map.infrastructure.exposed.MapPictogramEntity
@@ -69,6 +71,15 @@ class EventRepositoryExposed(
     private val database: Database,
     private val geocodeApi: GeocodeApi
 ) : EventRepository {
+
+    private fun findOpenFeedbackEventId(eventUuid: UUID): String? {
+        val integration = IntegrationEntity.findIntegration(
+            eventId = eventUuid,
+            provider = IntegrationProvider.OPENFEEDBACK,
+            usage = IntegrationUsage.FEEDBACK
+        ) ?: return null
+        return OpenFeedbackIntegrationsTable[integration.id.value]?.eventId
+    }
 
     override suspend fun list(): EventList = transaction(db = database) {
         val events = EventEntity.all()
@@ -243,7 +254,7 @@ class EventRepositoryExposed(
             menus = menus,
             qanda = qanda,
             coc = event.coc ?: "",
-            openfeedbackProjectId = null,
+            openfeedbackProjectId = findOpenFeedbackEventId(eventUuid),
             features = features,
             contactPhone = event.contactPhone,
             contactEmail = event.contactEmail ?: "",
@@ -298,7 +309,7 @@ class EventRepositoryExposed(
             endDate = event.endDate.toString(),
             menus = menus,
             coc = event.coc ?: "",
-            openfeedbackProjectId = null,
+            openfeedbackProjectId = findOpenFeedbackEventId(eventUuid),
             features = features,
             contactPhone = event.contactPhone,
             contactEmail = event.contactEmail ?: "",
@@ -356,7 +367,7 @@ class EventRepositoryExposed(
             endDate = event.endDate.toString(),
             menus = menus,
             coc = event.coc ?: "",
-            openfeedbackProjectId = null,
+            openfeedbackProjectId = findOpenFeedbackEventId(eventUuid),
             features = features,
             contactPhone = event.contactPhone,
             contactEmail = event.contactEmail ?: "",
@@ -437,7 +448,7 @@ class EventRepositoryExposed(
             },
             maps = maps,
             thirdParty = ThirdParty(
-                openfeedbackProjectId = null
+                openfeedbackProjectId = findOpenFeedbackEventId(eventUuid)
             ),
             updatedAt = event.updatedAt.toEpochMilliseconds()
         )

--- a/backend/src/main/java/com/paligot/confily/backend/integrations/domain/CreateIntegration.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/integrations/domain/CreateIntegration.kt
@@ -30,4 +30,10 @@ sealed interface CreateIntegration {
         @SerialName("header_auth")
         val headerAuth: String? = null
     ) : CreateIntegration
+
+    @Serializable
+    class CreateOpenFeedbackIntegration(
+        @SerialName("event_id")
+        val eventId: String
+    ) : CreateIntegration
 }

--- a/backend/src/main/java/com/paligot/confily/backend/integrations/domain/IntegrationProvider.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/integrations/domain/IntegrationProvider.kt
@@ -16,5 +16,8 @@ enum class IntegrationProvider {
     PARTNERSCONNECT,
 
     @SerialName("webhook")
-    WEBHOOK
+    WEBHOOK,
+
+    @SerialName("openfeedback")
+    OPENFEEDBACK
 }

--- a/backend/src/main/java/com/paligot/confily/backend/integrations/domain/IntegrationUsage.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/integrations/domain/IntegrationUsage.kt
@@ -13,5 +13,8 @@ enum class IntegrationUsage {
     AGENDA,
 
     @SerialName("webhook")
-    WEBHOOK
+    WEBHOOK,
+
+    @SerialName("feedback")
+    FEEDBACK
 }

--- a/backend/src/main/java/com/paligot/confily/backend/integrations/infrastructure/api/IntegrationDeserializerRegistry.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/integrations/infrastructure/api/IntegrationDeserializerRegistry.kt
@@ -14,6 +14,7 @@ class DefaultIntegrationDeserializerRegistry : IntegrationDeserializerRegistry {
         IntegrationProvider.SLACK to CreateIntegration.CreateSlackIntegration.serializer(),
         IntegrationProvider.BILLETWEB to CreateIntegration.CreateBilletWebIntegration.serializer(),
         IntegrationProvider.OPENPLANNER to CreateIntegration.CreateOpenPlannerIntegration.serializer(),
+        IntegrationProvider.OPENFEEDBACK to CreateIntegration.CreateOpenFeedbackIntegration.serializer(),
         IntegrationProvider.WEBHOOK to CreateIntegration.CreateWebhookIntegration.serializer()
     )
 

--- a/backend/src/main/java/com/paligot/confily/backend/integrations/infrastructure/exposed/OpenFeedbackIntegrationsTable.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/integrations/infrastructure/exposed/OpenFeedbackIntegrationsTable.kt
@@ -1,0 +1,22 @@
+package com.paligot.confily.backend.integrations.infrastructure.exposed
+
+import org.jetbrains.exposed.sql.ReferenceOption
+import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.selectAll
+import java.util.UUID
+
+object OpenFeedbackIntegrationsTable : Table("openfeedback_integrations") {
+    val integrationId = reference("integration_id", IntegrationsTable, onDelete = ReferenceOption.CASCADE)
+    val eventId = varchar("event_id", 255)
+
+    override val primaryKey = PrimaryKey(integrationId)
+}
+
+data class OpenFeedbackConfig(val eventId: String)
+
+operator fun OpenFeedbackIntegrationsTable.get(integrationId: UUID): OpenFeedbackConfig? =
+    OpenFeedbackIntegrationsTable
+        .selectAll()
+        .where { OpenFeedbackIntegrationsTable.integrationId eq integrationId }
+        .map { OpenFeedbackConfig(eventId = it[OpenFeedbackIntegrationsTable.eventId]) }
+        .singleOrNull()

--- a/backend/src/main/java/com/paligot/confily/backend/integrations/infrastructure/exposed/OpenFeedbackRegistrar.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/integrations/infrastructure/exposed/OpenFeedbackRegistrar.kt
@@ -1,0 +1,47 @@
+package com.paligot.confily.backend.integrations.infrastructure.exposed
+
+import com.paligot.confily.backend.integrations.domain.CreateIntegration
+import com.paligot.confily.backend.integrations.domain.IntegrationProvider
+import com.paligot.confily.backend.integrations.domain.IntegrationRegistrar
+import com.paligot.confily.backend.integrations.domain.IntegrationUsage
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.deleteWhere
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.insertAndGetId
+import org.jetbrains.exposed.sql.transactions.transaction
+import java.util.UUID
+
+class OpenFeedbackRegistrar(
+    private val database: Database
+) : IntegrationRegistrar<CreateIntegration.CreateOpenFeedbackIntegration> {
+    override val supportedUsages: Set<IntegrationUsage> = setOf(IntegrationUsage.FEEDBACK)
+
+    override fun register(
+        eventId: String,
+        usage: IntegrationUsage,
+        input: CreateIntegration.CreateOpenFeedbackIntegration
+    ): String = transaction(db = database) {
+        val integrationId = IntegrationsTable.insertAndGetId {
+            it[this.eventId] = UUID.fromString(eventId)
+            it[this.provider] = IntegrationProvider.OPENFEEDBACK
+            it[this.usage] = usage
+        }
+        OpenFeedbackIntegrationsTable.insert {
+            it[this.integrationId] = integrationId.value
+            it[this.eventId] = input.eventId
+        }
+        integrationId.value.toString()
+    }
+
+    override fun unregister(integrationId: String): Unit = transaction(db = database) {
+        val integrationUuid = UUID.fromString(integrationId)
+        OpenFeedbackIntegrationsTable.deleteWhere {
+            OpenFeedbackIntegrationsTable.integrationId eq integrationUuid
+        }
+        IntegrationsTable.deleteWhere { IntegrationsTable.id eq integrationUuid }
+    }
+
+    override fun supports(input: CreateIntegration): Boolean =
+        input is CreateIntegration.CreateOpenFeedbackIntegration
+}

--- a/backend/src/main/java/com/paligot/confily/backend/integrations/infrastructure/factory/IntegrationModule.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/integrations/infrastructure/factory/IntegrationModule.kt
@@ -3,6 +3,7 @@ package com.paligot.confily.backend.integrations.infrastructure.factory
 import com.paligot.confily.backend.integrations.application.IntegrationRepositoryExposed
 import com.paligot.confily.backend.integrations.infrastructure.api.DefaultIntegrationDeserializerRegistry
 import com.paligot.confily.backend.integrations.infrastructure.exposed.BilletWebRegistrar
+import com.paligot.confily.backend.integrations.infrastructure.exposed.OpenFeedbackRegistrar
 import com.paligot.confily.backend.integrations.infrastructure.exposed.OpenPlannerRegistrar
 import com.paligot.confily.backend.integrations.infrastructure.exposed.SlackRegistrar
 import com.paligot.confily.backend.integrations.infrastructure.exposed.WebhookRegistrar
@@ -17,6 +18,7 @@ object IntegrationModule {
             registrars = listOf(
                 BilletWebRegistrar(PostgresModule.database),
                 OpenPlannerRegistrar(PostgresModule.database),
+                OpenFeedbackRegistrar(PostgresModule.database),
                 SlackRegistrar(PostgresModule.database),
                 WebhookRegistrar(PostgresModule.database)
             )

--- a/backend/src/main/java/com/paligot/confily/backend/internals/infrastructure/exposed/DatabaseFactory.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/internals/infrastructure/exposed/DatabaseFactory.kt
@@ -10,6 +10,7 @@ import com.paligot.confily.backend.events.infrastructure.exposed.EventsTable
 import com.paligot.confily.backend.formats.infrastructure.exposed.FormatsTable
 import com.paligot.confily.backend.integrations.infrastructure.exposed.BilletWebIntegrationsTable
 import com.paligot.confily.backend.integrations.infrastructure.exposed.IntegrationsTable
+import com.paligot.confily.backend.integrations.infrastructure.exposed.OpenFeedbackIntegrationsTable
 import com.paligot.confily.backend.integrations.infrastructure.exposed.OpenPlannerIntegrationsTable
 import com.paligot.confily.backend.integrations.infrastructure.exposed.SlackIntegrationsTable
 import com.paligot.confily.backend.integrations.infrastructure.exposed.WebhookIntegrationsTable
@@ -87,6 +88,7 @@ object DatabaseFactory {
         IntegrationsTable,
         BilletWebIntegrationsTable,
         OpenPlannerIntegrationsTable,
+        OpenFeedbackIntegrationsTable,
         SlackIntegrationsTable,
         WebhookIntegrationsTable
     )

--- a/backend/src/main/java/com/paligot/confily/backend/planning/application/PlanningRepositoryExposed.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/planning/application/PlanningRepositoryExposed.kt
@@ -7,6 +7,11 @@ import com.paligot.confily.backend.events.infrastructure.exposed.EventEntity
 import com.paligot.confily.backend.formats.infrastructure.exposed.FormatEntity
 import com.paligot.confily.backend.formats.infrastructure.exposed.FormatsTable
 import com.paligot.confily.backend.formats.infrastructure.exposed.toModel
+import com.paligot.confily.backend.integrations.domain.IntegrationProvider
+import com.paligot.confily.backend.integrations.domain.IntegrationUsage
+import com.paligot.confily.backend.integrations.infrastructure.exposed.IntegrationEntity
+import com.paligot.confily.backend.integrations.infrastructure.exposed.OpenFeedbackIntegrationsTable
+import com.paligot.confily.backend.integrations.infrastructure.exposed.get
 import com.paligot.confily.backend.planning.domain.PlanningRepository
 import com.paligot.confily.backend.schedules.infrastructure.exposed.ScheduleEntity
 import com.paligot.confily.backend.schedules.infrastructure.exposed.SchedulesTable
@@ -42,6 +47,31 @@ class PlanningRepositoryExposed(
     private val format = LocalDateTime.Format {
         hour(); char(':'); minute()
     }
+
+    private fun findOpenFeedbackEventId(eventUuid: UUID): String? {
+        val integration = IntegrationEntity.findIntegration(
+            eventId = eventUuid,
+            provider = IntegrationProvider.OPENFEEDBACK,
+            usage = IntegrationUsage.FEEDBACK
+        ) ?: return null
+        return OpenFeedbackIntegrationsTable[integration.id.value]?.eventId
+    }
+
+    private fun buildSessionDateMap(
+        eventUuid: UUID,
+        timezone: TimeZone
+    ): Map<UUID, String> = ScheduleEntity
+        .findWithSession(eventUuid)
+        .associate {
+            it.session!!.id.value to
+                it.startTime.toLocalDateTime(timezone).date.toString()
+        }
+
+    private fun buildOpenFeedbackUrl(
+        openFeedbackEventId: String,
+        date: String,
+        sessionId: String
+    ): String = "https://openfeedback.io/$openFeedbackEventId/$date/$sessionId"
 
     private fun protect(value: String): String =
         if (value.contains(",") || value.contains('"')) {
@@ -142,9 +172,26 @@ class PlanningRepositoryExposed(
 
     override suspend fun planning(eventId: String): AgendaV3 = transaction(db = database) {
         val eventUuid = UUID.fromString(eventId)
+        val event = EventEntity[eventUuid]
+        val timezone = TimeZone.of(event.timezone)
+        val openFeedbackEventId = findOpenFeedbackEventId(eventUuid)
+        val sessionDateMap = if (openFeedbackEventId != null) {
+            buildSessionDateMap(eventUuid, timezone)
+        } else {
+            emptyMap()
+        }
         val sessions = SessionEntity
             .findByEvent(eventUuid)
-            .map { it.toModelV3() }
+            .map { session ->
+                val sessionUuid = session.id.value
+                val date = sessionDateMap[sessionUuid]
+                val url = if (openFeedbackEventId != null && date != null) {
+                    buildOpenFeedbackUrl(openFeedbackEventId, date, sessionUuid.toString())
+                } else {
+                    null
+                }
+                session.toModelV3(openFeedbackUrl = url)
+            }
         AgendaV3(
             sessions = ScheduleEntity
                 .findByEvent(eventUuid)
@@ -166,9 +213,26 @@ class PlanningRepositoryExposed(
 
     override suspend fun planningBySchedules(eventId: String): AgendaV4 = transaction(db = database) {
         val eventUuid = UUID.fromString(eventId)
+        val event = EventEntity[eventUuid]
+        val timezone = TimeZone.of(event.timezone)
+        val openFeedbackEventId = findOpenFeedbackEventId(eventUuid)
+        val sessionDateMap = if (openFeedbackEventId != null) {
+            buildSessionDateMap(eventUuid, timezone)
+        } else {
+            emptyMap()
+        }
         val sessions = SessionEntity
             .findByEvent(eventUuid)
-            .map { it.toSessionModel() }
+            .map { session ->
+                val sessionUuid = session.id.value
+                val date = sessionDateMap[sessionUuid]
+                val url = if (openFeedbackEventId != null && date != null) {
+                    buildOpenFeedbackUrl(openFeedbackEventId, date, sessionUuid.toString())
+                } else {
+                    null
+                }
+                session.toSessionModel(openFeedbackUrl = url)
+            }
         val eventSessions = EventSessionEntity
             .findByEvent(eventUuid)
             .map { it.toModel() }

--- a/backend/src/main/java/com/paligot/confily/backend/sessions/infrastructure/exposed/SessionMappers.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/sessions/infrastructure/exposed/SessionMappers.kt
@@ -8,7 +8,7 @@ import com.paligot.confily.models.Session
 import com.paligot.confily.models.Talk
 import com.paligot.confily.models.TalkV3
 
-fun SessionEntity.toModel(): Talk {
+fun SessionEntity.toModel(openFeedbackUrl: String? = null): Talk {
     val sessionUuid = this.id.value
     val categoryEntity = SessionCategoriesTable.firstCategoryId(sessionUuid)
         ?.let { CategoryEntity[it] }
@@ -33,11 +33,11 @@ fun SessionEntity.toModel(): Talk {
         speakers = speakers.map { it.toModel() },
         linkSlides = this.linkSlides,
         linkReplay = this.linkReplay,
-        openFeedback = null
+        openFeedback = openFeedbackUrl
     )
 }
 
-fun SessionEntity.toModelV3(): TalkV3 {
+fun SessionEntity.toModelV3(openFeedbackUrl: String? = null): TalkV3 {
     val sessionUuid = this.id.value
     val categoryEntity = SessionCategoriesTable.firstCategoryId(sessionUuid)
         ?.let { CategoryEntity[it] }
@@ -54,11 +54,11 @@ fun SessionEntity.toModelV3(): TalkV3 {
         speakers = speakers.map { it.id.value.toString() },
         linkSlides = this.linkSlides,
         linkReplay = this.linkReplay,
-        openFeedback = null
+        openFeedback = openFeedbackUrl
     )
 }
 
-fun SessionEntity.toSessionModel(): Session.Talk {
+fun SessionEntity.toSessionModel(openFeedbackUrl: String? = null): Session.Talk {
     val sessionUuid = this.id.value
     val categoryEntity = SessionCategoriesTable.firstCategoryId(sessionUuid)
         ?.let { CategoryEntity[it] }
@@ -75,7 +75,7 @@ fun SessionEntity.toSessionModel(): Session.Talk {
         speakers = speakers.map { it.id.value.toString() },
         linkSlides = this.linkSlides,
         linkReplay = this.linkReplay,
-        openFeedback = null,
+        openFeedback = openFeedbackUrl,
         tagIds = emptyList()
     )
 }


### PR DESCRIPTION
## Summary

Adds OpenFeedback as a configurable integration on events, so each session in the planning endpoints returns an OpenFeedback URL.

## Changes

- **New integration provider**: `OPENFEEDBACK` with `FEEDBACK` usage type
- **New table**: `openfeedback_integrations` storing the OpenFeedback project event ID per integration
- **New registrar**: `OpenFeedbackRegistrar` following the existing integration pattern
- **Session URLs**: Planning endpoints (V3 & V4) now build `https://openfeedback.io/{eventId}/{YYYY-MM-DD}/{sessionId}` for each session when an OpenFeedback integration is configured
- **Event responses**: `openfeedbackProjectId` is now populated from the integration config in V2, V3, V4, and V5 event endpoints

## Usage

Register an OpenFeedback integration:
```
POST /integrations/openfeedback/feedback
{"event_id": "your-openfeedback-project-id"}
```

Sessions will then include the `open_feedback` field with the full URL.