### PR TITLE
Fix event sessions missing from schedule in mobile apps

### DIFF
--- a/backend/src/main/java/com/paligot/confily/backend/schedules/infrastructure/exposed/ScheduleMappers.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/schedules/infrastructure/exposed/ScheduleMappers.kt
@@ -30,7 +30,7 @@ fun ScheduleEntity.toModelV3(): ScheduleItemV3 {
         startTime = this.startTime.toLocalDateTime(timezone).toString(),
         endTime = this.endTime.toLocalDateTime(timezone).toString(),
         room = this.eventSessionTrack.trackName,
-        talkId = this.session?.id?.value.toString()
+        talkId = this.session?.id?.value?.toString()
     )
 }
 
@@ -43,6 +43,6 @@ fun ScheduleEntity.toModelV4(): ScheduleItemV4 {
         startTime = this.startTime.toLocalDateTime(timezone).toString(),
         endTime = this.endTime.toLocalDateTime(timezone).toString(),
         room = this.eventSessionTrack.trackName,
-        sessionId = this.session?.id?.value.toString()
+        sessionId = (this.session?.id?.value ?: this.eventSession?.id?.value).toString()
     )
 }


### PR DESCRIPTION
## Problem

Event sessions (breaks, lunch, registration, etc.) are not displayed in the schedule on Android and iOS apps. Only talk sessions appear.

## Root Cause

In `ScheduleMappers.kt`, the V4 mapper called `.toString()` on a nullable UUID:

```kotlin
sessionId = this.session?.id?.value.toString()
```

When `session` is null (which is the case for event sessions), this produces the **string literal `"null"`** instead of the actual event session ID. The mobile app's SQLDelight query JOINs `Schedule.session_id` with `EventSession.id`, and since no event session has id `"null"`, zero event sessions are returned.

## Fix

- **V4 mapper**: Fall back to `eventSession?.id?.value` when `session` is null, so the `sessionId` field correctly references the event session.
- **V3 mapper**: Fix the same `.toString()` pattern on `talkId` to return actual `null` instead of the string `"null"`.

## No mobile changes needed

Both Compose (`SmallPauseItem` / `MediumPauseItem`) and SwiftUI (`EventSessionItemNavigation` / `EventSessionView`) already handle `EventSessionItemUi` in their schedule lists. Once the backend returns proper event session IDs, both platforms will display event sessions correctly.