### PR TITLE
Improve favorite reminder notifications on Android

### DIFF
--- a/.github/skills/post-edit-verification/SKILL.md
+++ b/.github/skills/post-edit-verification/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: post-edit-verification
-description: "Use this skill after every working session where Kotlin or Android code was created or modified. It ensures the project compiles and passes lint checks before considering work complete. Run the verification commands below and fix any issues before committing."
+description: "Use this skill after every working session where Kotlin or Android code was created or modified, and ALWAYS before committing, opening a PR, or reporting work as done. Runs the same three quality gates CI runs — ktlint, detekt, and Android lint — so failures are caught locally instead of by GitHub Actions."
 ---
 
 # Post-Edit Verification Skill
 
 ## When to Use
 
-Run these checks **after every working session** that touches Kotlin, Android, or shared module code — before committing or reporting work as done.
+Run these checks **after every working session** that touches Kotlin, Android, or shared module code — before committing, before opening a PR, before reporting work as done. CI fails on any of the three checks below; run them locally to avoid the round-trip.
+
+## CI Reference
+
+`.github/workflows/build.yaml` (job `linter`) runs exactly two commands. Both must succeed:
+
+```bash
+./gradlew ktlintCheck detekt
+./gradlew lintDebug
+```
+
+Mirror these locally — do not skip Android lint just because ktlint and detekt passed. They catch different classes of issues (Android lint covers `MissingPermission`, `UnusedResources`, manifest checks, etc. that ktlint and detekt don't).
 
 ## Compilation Check
 
-Compile the modules you modified. Target the specific Gradle tasks for faster feedback:
+Compile the modules you modified. Target specific Gradle tasks for faster feedback:
 
 ```bash
 # Android modules
@@ -32,28 +43,50 @@ Examples for common modules:
 ./gradlew :shared:core:compileKotlinIosArm64
 ```
 
-## Lint Check
+## Quality Gates
 
-Run both ktlint and detekt. Both must pass with zero violations:
+All three must pass with zero violations.
+
+### 1. ktlint + detekt
 
 ```bash
 ./gradlew ktlintCheck detekt
 ```
 
-See the `kotlin-linting` skill for rules and thresholds.
+See the `kotlin-linting` skill for rules and thresholds. Auto-fix ktlint issues with `./gradlew ktlintFormat`. Detekt cannot auto-fix — review `build/reports/detekt/`.
+
+### 2. Android lint
+
+```bash
+./gradlew lintDebug
+```
+
+Android lint runs on all Android-targeting modules. Fail-fast scope: `:androidApp:lintDebug` is enough if you only touched the app module, but the top-level `lintDebug` matches CI exactly. Reports land in `androidApp/build/reports/lint-results-debug.html`.
+
+Android lint catches issues the Kotlin tools don't:
+- `MissingPermission` — calls that need a runtime permission check
+- `UnusedResources`, `IconMissingDensityFolder`, etc. — resource hygiene
+- Manifest issues — `exported` flags, intent filters, deprecated APIs
+- API-level usage — calls to APIs above `minSdk` without a `Build.VERSION.SDK_INT` guard
+
+When suppression is genuinely warranted, use `@SuppressLint("RuleId")` at the smallest possible scope and add a one-line comment explaining why the static check is wrong (e.g., the runtime check is stronger but lint can't see it).
 
 ## Common Issues
 
-| Issue | Fix |
-|---|---|
-| Import ordering (ktlint) | Imports must be lexicographically sorted with no blank lines between them. `java`, `javax`, `kotlin` and aliases go last. |
-| Missing private helper functions | If you reference a function in a composable, make sure it exists in the same file or is imported. |
-| Wildcard imports | Always use explicit imports. Never use `*`. |
-| Duplicate imports | When adding a new import, check it isn't already present elsewhere in the import block. Place it in the correct alphabetical position. |
+| Issue | Tool | Fix |
+|---|---|---|
+| Import ordering | ktlint | Imports must be lexicographically sorted with no blank lines between them. `java`, `javax`, `kotlin` and aliases go last. |
+| Wildcard imports | ktlint | Always use explicit imports. Never use `*`. |
+| Duplicate imports | ktlint | When adding a new import, check it isn't already present elsewhere in the import block. Place it in the correct alphabetical position. |
+| `ReturnCount` (>2) | detekt | Collapse early returns into a single guard, or extract a helper function. |
+| `ComplexCondition` (>3 boolean ops) | detekt | Break the condition apart, or extract validation into a helper. |
+| `MissingPermission` on `notify()`, location calls, etc. | Android lint | Call `ContextCompat.checkSelfPermission` (or an equivalent gate like `NotificationManagerCompat.areNotificationsEnabled()`); if the gate is semantically stronger but lint can't see it, suppress at the function with a justifying comment. |
+| Missing private helper functions | compile | If you reference a function in a composable, make sure it exists in the same file or is imported. |
 
 ## Checklist
 
 1. Compile modified modules — `BUILD SUCCESSFUL`
-2. Run `./gradlew ktlintCheck detekt` — `BUILD SUCCESSFUL`
-3. Fix any errors and re-run until clean
-4. Then commit
+2. `./gradlew ktlintCheck detekt` — `BUILD SUCCESSFUL`
+3. `./gradlew lintDebug` — `BUILD SUCCESSFUL`
+4. Fix any errors and re-run until all three are clean
+5. Then commit / open the PR

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -40,6 +40,7 @@ dependencies {
     implementation(libs.androidx.profile)
     implementation(libs.androidx.workmanager.ktx)
     implementation(libs.bundles.androidx.glance)
+    implementation(libs.google.accompanist.permissions)
     implementation(libs.google.material)
 
     implementation(libs.jetbrains.navigation.compose)

--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -7,6 +7,9 @@
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+    <uses-permission android:name="android.permission.USE_EXACT_ALARM"/>
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"
+                     android:maxSdkVersion="32"/>
 
     <application
             android:name=".MainApplication"
@@ -39,11 +42,7 @@
 
         <receiver
                 android:name=".AlarmReceiver"
-                android:exported="true">
-            <intent-filter>
-                <action android:name="android.intent.action.NOTIFY" />
-            </intent-filter>
-        </receiver>
+                android:exported="false"/>
 
         <receiver android:name=".widgets.AppWidgetReceiver"
                 android:exported="true"

--- a/androidApp/src/main/kotlin/com/paligot/confily/android/AlarmIntentFactoryImpl.kt
+++ b/androidApp/src/main/kotlin/com/paligot/confily/android/AlarmIntentFactoryImpl.kt
@@ -3,8 +3,6 @@ package com.paligot.confily.android
 import android.content.Context
 import android.content.Intent
 import com.paligot.confily.core.AlarmIntentFactory
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 
 object AlarmIntentFactoryImpl : AlarmIntentFactory {
     const val CHANNEL_ID = "alarm.notification"
@@ -12,8 +10,6 @@ object AlarmIntentFactoryImpl : AlarmIntentFactory {
     const val TITLE = "alarm.title"
     const val TEXT = "alarm.text"
 
-    @FlowPreview
-    @ExperimentalCoroutinesApi
     override fun create(context: Context, id: String, title: String, text: String): Intent =
         Intent(context, AlarmReceiver::class.java).apply {
             putExtra(ID, id)

--- a/androidApp/src/main/kotlin/com/paligot/confily/android/AlarmReceiver.kt
+++ b/androidApp/src/main/kotlin/com/paligot/confily/android/AlarmReceiver.kt
@@ -1,5 +1,6 @@
 package com.paligot.confily.android
 
+import android.annotation.SuppressLint
 import android.app.PendingIntent
 import android.content.BroadcastReceiver
 import android.content.Context
@@ -14,6 +15,10 @@ class AlarmReceiver : BroadcastReceiver() {
         }
     }
 
+    // areNotificationsEnabled() returns false on API 33+ when POST_NOTIFICATIONS
+    // is not granted, so the notify() call below is gated by an effective
+    // runtime-permission check that lint can't detect statically.
+    @SuppressLint("MissingPermission")
     private fun showReminder(context: Context, intent: Intent) {
         val id = intent.getStringExtra(AlarmIntentFactoryImpl.ID)
         val title = intent.getStringExtra(AlarmIntentFactoryImpl.TITLE)

--- a/androidApp/src/main/kotlin/com/paligot/confily/android/AlarmReceiver.kt
+++ b/androidApp/src/main/kotlin/com/paligot/confily/android/AlarmReceiver.kt
@@ -9,10 +9,18 @@ import androidx.core.app.NotificationManagerCompat
 
 class AlarmReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context?, intent: Intent?) {
-        if (intent == null || context == null) return
-        val id = intent.getStringExtra(AlarmIntentFactoryImpl.ID) ?: return
-        val title = intent.getStringExtra(AlarmIntentFactoryImpl.TITLE) ?: return
-        val text = intent.getStringExtra(AlarmIntentFactoryImpl.TEXT) ?: return
+        if (context != null && intent != null) {
+            showReminder(context, intent)
+        }
+    }
+
+    private fun showReminder(context: Context, intent: Intent) {
+        val id = intent.getStringExtra(AlarmIntentFactoryImpl.ID)
+        val title = intent.getStringExtra(AlarmIntentFactoryImpl.TITLE)
+        val text = intent.getStringExtra(AlarmIntentFactoryImpl.TEXT)
+        if (id == null || title == null || text == null) return
+        val notificationManager = NotificationManagerCompat.from(context)
+        if (!notificationManager.areNotificationsEnabled()) return
         val notification = NotificationCompat.Builder(context, AlarmIntentFactoryImpl.CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_campaign)
             .setContentTitle(title)
@@ -29,8 +37,6 @@ class AlarmReceiver : BroadcastReceiver() {
             )
             .setAutoCancel(true)
             .build()
-        val notificationManager = NotificationManagerCompat.from(context)
-        if (!notificationManager.areNotificationsEnabled()) return
         notificationManager.notify(id.hashCode(), notification)
     }
 }

--- a/androidApp/src/main/kotlin/com/paligot/confily/android/AlarmReceiver.kt
+++ b/androidApp/src/main/kotlin/com/paligot/confily/android/AlarmReceiver.kt
@@ -1,36 +1,25 @@
 package com.paligot.confily.android
 
-import android.annotation.SuppressLint
-import android.app.NotificationChannel
-import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import android.os.Build
 import androidx.core.app.NotificationCompat
-import com.russhwolf.settings.ExperimentalSettingsApi
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
+import androidx.core.app.NotificationManagerCompat
 
-@Suppress("DEPRECATION")
-@FlowPreview
-@ExperimentalCoroutinesApi
 class AlarmReceiver : BroadcastReceiver() {
-    @OptIn(ExperimentalSettingsApi::class)
-    @SuppressLint("UnspecifiedImmutableFlag")
     override fun onReceive(context: Context?, intent: Intent?) {
         if (intent == null || context == null) return
-        val id = intent.extras!![AlarmIntentFactoryImpl.ID] as String
-        val title = intent.extras!![AlarmIntentFactoryImpl.TITLE] as String
-        val text = intent.extras!![AlarmIntentFactoryImpl.TEXT] as String
-        val builder = NotificationCompat.Builder(context, AlarmIntentFactoryImpl.CHANNEL_ID).apply {
-            setSmallIcon(R.drawable.ic_campaign)
-            setContentTitle(title)
-            setContentText(text)
-            setStyle(NotificationCompat.BigTextStyle().bigText(text))
-            priority = NotificationCompat.PRIORITY_DEFAULT
-            setContentIntent(
+        val id = intent.getStringExtra(AlarmIntentFactoryImpl.ID) ?: return
+        val title = intent.getStringExtra(AlarmIntentFactoryImpl.TITLE) ?: return
+        val text = intent.getStringExtra(AlarmIntentFactoryImpl.TEXT) ?: return
+        val notification = NotificationCompat.Builder(context, AlarmIntentFactoryImpl.CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_campaign)
+            .setContentTitle(title)
+            .setContentText(text)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(text))
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setContentIntent(
                 PendingIntent.getActivity(
                     context,
                     0,
@@ -38,15 +27,10 @@ class AlarmReceiver : BroadcastReceiver() {
                     PendingIntent.FLAG_IMMUTABLE
                 )
             )
-            setAutoCancel(true)
-        }
-        val notificationManager: NotificationManager =
-            context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val importance = NotificationManager.IMPORTANCE_DEFAULT
-            val channel = NotificationChannel(AlarmIntentFactoryImpl.CHANNEL_ID, "Devfest Lille App", importance)
-            notificationManager.createNotificationChannel(channel)
-        }
-        notificationManager.notify(id.hashCode(), builder.build())
+            .setAutoCancel(true)
+            .build()
+        val notificationManager = NotificationManagerCompat.from(context)
+        if (!notificationManager.areNotificationsEnabled()) return
+        notificationManager.notify(id.hashCode(), notification)
     }
 }

--- a/androidApp/src/main/kotlin/com/paligot/confily/android/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/paligot/confily/android/MainActivity.kt
@@ -9,6 +9,7 @@ import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
@@ -22,6 +23,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import com.paligot.confily.BuildKonfig
 import com.paligot.confily.android.widgets.NetworkingAppWidget
+import com.paligot.confily.core.LocalNotificationPermissionRequester
 import com.paligot.confily.main.Main
 import com.paligot.confily.resources.Resource
 import com.paligot.confily.resources.text_export_subject
@@ -67,61 +69,66 @@ class MainActivity : ComponentActivity() {
             val exportSubject = stringResource(Resource.string.text_export_subject)
             val reportSubject = stringResource(Resource.string.text_report_subject)
             val reportAppTarget = stringResource(Resource.string.text_report_app_target)
-            Main(
-                defaultEvent = BuildKonfig.DEFAULT_EVENT,
-                isPortrait = config.isPortrait,
-                launchUrl = { launchUrl(it) },
-                onContactExportClicked = { export ->
-                    val uri: Uri = FileProvider.getUriForFile(
-                        applicationContext,
-                        "${applicationContext.packageName}.provider",
-                        File(export.filePath)
-                    )
-                    val intent = ShareCompat.IntentBuilder(this)
-                        .setStream(uri)
-                        .intent
-                        .setAction(Intent.ACTION_SENDTO)
-                        .setData(Uri.parse("mailto:${export.mailto ?: ""}"))
-                        .putExtra(Intent.EXTRA_SUBJECT, exportSubject)
-                        .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-                    startActivity(intent)
-                },
-                onReportByPhoneClicked = {
-                    val intent = Intent(Intent.ACTION_DIAL).apply {
-                        data = Uri.parse("tel:$it")
-                    }
-                    startActivity(intent)
-                },
-                onReportByEmailClicked = {
-                    val intent = Intent(Intent.ACTION_SENDTO).apply {
-                        data = Uri.parse("mailto:$it")
-                        putExtra(Intent.EXTRA_SUBJECT, reportSubject)
-                    }
-                    startActivity(Intent.createChooser(intent, reportAppTarget))
-                },
-                onShareClicked = { text ->
-                    val sendIntent = Intent(Intent.ACTION_SEND).apply {
-                        putExtra(Intent.EXTRA_TEXT, text)
-                        type = "text/plain"
-                    }
-                    val shareIntent = Intent.createChooser(sendIntent, null)
-                    startActivity(shareIntent)
-                },
-                onItineraryClicked = { lat, lng ->
-                    val intent = Intent(Intent.ACTION_VIEW).apply {
-                        data = Uri.parse("google.navigation:q=$lat,$lng")
-                    }
-                    val shareIntent = Intent.createChooser(intent, null)
-                    startActivity(shareIntent)
-                },
-                onProfileCreated = {
-                    scope.launch { NetworkingAppWidget().updateAll(context = this@MainActivity) }
-                },
-                modifier = Modifier.semantics {
-                    testTagsAsResourceId = true
-                },
-                navController = navController
-            )
+            val notificationPermissionRequester = rememberNotificationPermissionRequester()
+            CompositionLocalProvider(
+                LocalNotificationPermissionRequester provides notificationPermissionRequester
+            ) {
+                Main(
+                    defaultEvent = BuildKonfig.DEFAULT_EVENT,
+                    isPortrait = config.isPortrait,
+                    launchUrl = { launchUrl(it) },
+                    onContactExportClicked = { export ->
+                        val uri: Uri = FileProvider.getUriForFile(
+                            applicationContext,
+                            "${applicationContext.packageName}.provider",
+                            File(export.filePath)
+                        )
+                        val intent = ShareCompat.IntentBuilder(this)
+                            .setStream(uri)
+                            .intent
+                            .setAction(Intent.ACTION_SENDTO)
+                            .setData(Uri.parse("mailto:${export.mailto ?: ""}"))
+                            .putExtra(Intent.EXTRA_SUBJECT, exportSubject)
+                            .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                        startActivity(intent)
+                    },
+                    onReportByPhoneClicked = {
+                        val intent = Intent(Intent.ACTION_DIAL).apply {
+                            data = Uri.parse("tel:$it")
+                        }
+                        startActivity(intent)
+                    },
+                    onReportByEmailClicked = {
+                        val intent = Intent(Intent.ACTION_SENDTO).apply {
+                            data = Uri.parse("mailto:$it")
+                            putExtra(Intent.EXTRA_SUBJECT, reportSubject)
+                        }
+                        startActivity(Intent.createChooser(intent, reportAppTarget))
+                    },
+                    onShareClicked = { text ->
+                        val sendIntent = Intent(Intent.ACTION_SEND).apply {
+                            putExtra(Intent.EXTRA_TEXT, text)
+                            type = "text/plain"
+                        }
+                        val shareIntent = Intent.createChooser(sendIntent, null)
+                        startActivity(shareIntent)
+                    },
+                    onItineraryClicked = { lat, lng ->
+                        val intent = Intent(Intent.ACTION_VIEW).apply {
+                            data = Uri.parse("google.navigation:q=$lat,$lng")
+                        }
+                        val shareIntent = Intent.createChooser(intent, null)
+                        startActivity(shareIntent)
+                    },
+                    onProfileCreated = {
+                        scope.launch { NetworkingAppWidget().updateAll(context = this@MainActivity) }
+                    },
+                    modifier = Modifier.semantics {
+                        testTagsAsResourceId = true
+                    },
+                    navController = navController
+                )
+            }
         }
     }
 

--- a/androidApp/src/main/kotlin/com/paligot/confily/android/MainApplication.kt
+++ b/androidApp/src/main/kotlin/com/paligot/confily/android/MainApplication.kt
@@ -1,6 +1,10 @@
 package com.paligot.confily.android
 
 import android.app.Application
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.os.Build
+import androidx.core.content.getSystemService
 import androidx.work.Constraints
 import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
@@ -44,6 +48,8 @@ class MainApplication : Application(), SingletonImageLoader.Factory, KoinCompone
             modules(appModule)
         }
 
+        createReminderNotificationChannel()
+
         val workManager = WorkManager.getInstance(this)
         val constraints = Constraints.Builder()
             .setRequiredNetworkType(NetworkType.CONNECTED)
@@ -52,6 +58,16 @@ class MainApplication : Application(), SingletonImageLoader.Factory, KoinCompone
             .setConstraints(constraints)
             .build()
         workManager.enqueue(request)
+    }
+
+    private fun createReminderNotificationChannel() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        val channel = NotificationChannel(
+            AlarmIntentFactoryImpl.CHANNEL_ID,
+            getString(R.string.notif_channel_reminders_name),
+            NotificationManager.IMPORTANCE_DEFAULT
+        )
+        getSystemService<NotificationManager>()?.createNotificationChannel(channel)
     }
 
     override fun newImageLoader(context: PlatformContext): ImageLoader =

--- a/androidApp/src/main/kotlin/com/paligot/confily/android/NotificationPermissionRequester.kt
+++ b/androidApp/src/main/kotlin/com/paligot/confily/android/NotificationPermissionRequester.kt
@@ -1,0 +1,26 @@
+package com.paligot.confily.android
+
+import android.Manifest
+import android.os.Build
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.google.accompanist.permissions.isGranted
+import com.google.accompanist.permissions.rememberPermissionState
+import com.paligot.confily.core.NotificationPermissionRequester
+
+@OptIn(ExperimentalPermissionsApi::class)
+@Composable
+fun rememberNotificationPermissionRequester(): NotificationPermissionRequester {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+        return NotificationPermissionRequester.Noop
+    }
+    val permissionState = rememberPermissionState(Manifest.permission.POST_NOTIFICATIONS)
+    return remember(permissionState) {
+        NotificationPermissionRequester {
+            if (!permissionState.status.isGranted) {
+                permissionState.launchPermissionRequest()
+            }
+        }
+    }
+}

--- a/androidApp/src/main/res/values-fr/strings.xml
+++ b/androidApp/src/main/res/values-fr/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="notif_channel_reminders_name">Rappels de talks</string>
+</resources>

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
     <string name="app_name" tools:ignore="MissingTranslation">Confily</string>
+    <string name="notif_channel_reminders_name">Talk reminders</string>
 </resources>

--- a/features/schedules/schedules-presentation/src/commonMain/kotlin/com/paligot/confily/schedules/presentation/ScheduleGridVM.kt
+++ b/features/schedules/schedules-presentation/src/commonMain/kotlin/com/paligot/confily/schedules/presentation/ScheduleGridVM.kt
@@ -5,9 +5,11 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
+import com.paligot.confily.core.LocalNotificationPermissionRequester
 import com.paligot.confily.resources.Resource
 import com.paligot.confily.resources.text_error
 import com.paligot.confily.schedules.panes.ScheduleGridPager
+import com.paligot.confily.schedules.ui.models.TalkItemUi
 import com.paligot.confily.style.theme.actions.TopActionsUi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
@@ -26,6 +28,11 @@ fun ScheduleGridVM(
     isSmallSize: Boolean = false,
     viewModel: ScheduleGridViewModel = koinViewModel()
 ) {
+    val notificationPermissionRequester = LocalNotificationPermissionRequester.current
+    val onFavoriteClicked: (TalkItemUi) -> Unit = { talkItem ->
+        if (!talkItem.isFavorite) notificationPermissionRequester.request()
+        viewModel.markAsFavorite(talkItem)
+    }
     when (val uiState = viewModel.uiState.collectAsState().value) {
         is ScheduleGridUiState.Loading -> ScheduleGridPager(
             agendas = uiState.agenda,
@@ -52,7 +59,7 @@ fun ScheduleGridVM(
             onTalkClicked = onTalkClicked,
             onEventSessionClicked = onEventSessionClicked,
             onFilterClicked = onFilterClicked,
-            onFavoriteClicked = viewModel::markAsFavorite,
+            onFavoriteClicked = onFavoriteClicked,
             onRefresh = viewModel::refreshing,
             modifier = modifier,
             isSmallSize = isSmallSize,

--- a/features/speakers/speakers-presentation/src/commonMain/kotlin/com/paligot/confily/speakers/presentation/SpeakerDetailVM.kt
+++ b/features/speakers/speakers-presentation/src/commonMain/kotlin/com/paligot/confily/speakers/presentation/SpeakerDetailVM.kt
@@ -4,8 +4,10 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
+import com.paligot.confily.core.LocalNotificationPermissionRequester
 import com.paligot.confily.resources.Resource
 import com.paligot.confily.resources.text_error
+import com.paligot.confily.schedules.ui.models.TalkItemUi
 import com.paligot.confily.speakers.panes.SpeakerDetailPane
 import com.paligot.confily.style.theme.appbars.AppBarIcons
 import org.jetbrains.compose.resources.stringResource
@@ -25,6 +27,11 @@ fun SpeakerDetailVM(
         parameters = { parametersOf(speakerId) }
     )
 ) {
+    val notificationPermissionRequester = LocalNotificationPermissionRequester.current
+    val onFavoriteClicked: (TalkItemUi) -> Unit = { talkItem ->
+        if (!talkItem.isFavorite) notificationPermissionRequester.request()
+        viewModel.markAsFavorite(talkItem)
+    }
     when (val uiState = viewModel.uiState.collectAsState().value) {
         is SpeakerUiState.Loading -> SpeakerDetailPane(
             speaker = uiState.speaker,
@@ -40,7 +47,7 @@ fun SpeakerDetailVM(
         is SpeakerUiState.Success -> SpeakerDetailPane(
             speaker = uiState.speaker,
             onTalkClicked = onTalkClicked,
-            onFavoriteClicked = viewModel::markAsFavorite,
+            onFavoriteClicked = onFavoriteClicked,
             onLinkClicked = onLinkClicked,
             modifier = modifier,
             navigationIcon = navigationIcon,

--- a/shared/core/src/androidMain/kotlin/com/paligot/confily/core/AlarmScheduler.android.kt
+++ b/shared/core/src/androidMain/kotlin/com/paligot/confily/core/AlarmScheduler.android.kt
@@ -1,16 +1,14 @@
 package com.paligot.confily.core
 
-import android.annotation.SuppressLint
 import android.app.AlarmManager
 import android.app.PendingIntent
 import android.content.Context
-import android.os.SystemClock
+import android.os.Build
 import com.paligot.confily.core.schedules.SessionRepository
 import com.paligot.confily.resources.Resource
 import com.paligot.confily.resources.title_notif_reminder_talk
 import com.paligot.confily.schedules.ui.models.TalkItemUi
 import kotlinx.coroutines.coroutineScope
-import kotlinx.datetime.Clock
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.minus
@@ -25,7 +23,6 @@ actual class AlarmScheduler(
     private val alarmManager: AlarmManager,
     private val alarmIntentFactory: AlarmIntentFactory
 ) {
-    @SuppressLint("UnspecifiedImmutableFlag")
     actual suspend fun schedule(talkItem: TalkItemUi) = coroutineScope {
         val isFavorite = !talkItem.isFavorite
         repository.markAsRead(talkItem.id, isFavorite)
@@ -34,23 +31,35 @@ actual class AlarmScheduler(
             talkItem.room.lowercase(Locale.getDefault())
         )
         val intent = alarmIntentFactory.create(context, talkItem.id, title, talkItem.title)
-        val flags =
-            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        val flags = PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
         val pendingIntent =
             PendingIntent.getBroadcast(context, talkItem.id.hashCode(), intent, flags)
         if (isFavorite) {
-            val time =
-                talkItem.startTime.toLocalDateTime().toInstant(TimeZone.UTC)
-                    .minus(ReminderInMinutes, DateTimeUnit.MINUTE).toEpochMilliseconds()
-            alarmManager.set(
-                AlarmManager.ELAPSED_REALTIME_WAKEUP,
-                SystemClock.elapsedRealtime() + (time - Clock.System.now().toEpochMilliseconds()),
-                pendingIntent
-            )
+            val triggerAtMillis = talkItem.startTime
+                .toLocalDateTime()
+                .toInstant(TimeZone.UTC)
+                .minus(ReminderInMinutes, DateTimeUnit.MINUTE)
+                .toEpochMilliseconds()
+            if (canScheduleExactAlarms()) {
+                alarmManager.setExactAndAllowWhileIdle(
+                    AlarmManager.RTC_WAKEUP,
+                    triggerAtMillis,
+                    pendingIntent
+                )
+            } else {
+                alarmManager.setAndAllowWhileIdle(
+                    AlarmManager.RTC_WAKEUP,
+                    triggerAtMillis,
+                    pendingIntent
+                )
+            }
         } else {
             alarmManager.cancel(pendingIntent)
         }
     }
+
+    private fun canScheduleExactAlarms(): Boolean =
+        Build.VERSION.SDK_INT < Build.VERSION_CODES.S || alarmManager.canScheduleExactAlarms()
 
     companion object {
         private const val ReminderInMinutes = 10

--- a/shared/core/src/commonMain/kotlin/com/paligot/confily/core/NotificationPermissionRequester.kt
+++ b/shared/core/src/commonMain/kotlin/com/paligot/confily/core/NotificationPermissionRequester.kt
@@ -1,0 +1,15 @@
+package com.paligot.confily.core
+
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.staticCompositionLocalOf
+
+fun interface NotificationPermissionRequester {
+    fun request()
+
+    companion object {
+        val Noop: NotificationPermissionRequester = NotificationPermissionRequester { }
+    }
+}
+
+val LocalNotificationPermissionRequester: ProvidableCompositionLocal<NotificationPermissionRequester> =
+    staticCompositionLocalOf { NotificationPermissionRequester.Noop }


### PR DESCRIPTION
## Summary

Fixes several issues that were preventing favorite reminders from firing reliably on Android — chief among them that `POST_NOTIFICATIONS` was never requested at runtime, so on Android 13+ notifications were silently dropped.

- **Lazy permission request**: Adds a `NotificationPermissionRequester` `CompositionLocal` (common) wired to an Accompanist-backed implementation in `androidApp`. The system dialog appears the first time the user adds a talk to favorites, not at app launch. Removing a favorite never triggers a prompt. On non-Android targets the default `Noop` keeps it as a no-op.
- **Reliable alarms**: Switches to `setExactAndAllowWhileIdle` with `RTC_WAKEUP` and the wall-clock target. Declares `USE_EXACT_ALARM` (Android 13+) and `SCHEDULE_EXACT_ALARM` (`maxSdkVersion="32"` for Android 12/12L). Defensive `canScheduleExactAlarms()` fallback to `setAndAllowWhileIdle` if the privilege is revoked at runtime.
- **Manifest hygiene**: `AlarmReceiver` is now `exported="false"` with no intent filter. The receiver is invoked through an explicit-component intent, so the previous filter was dead code with unnecessary attack surface.
- **Channel hygiene**: Notification channel is created once in `MainApplication.onCreate` with a localized name (`notif_channel_reminders_name` in EN/FR) instead of on every broadcast. `AlarmReceiver` short-circuits via `NotificationManagerCompat.areNotificationsEnabled()` when the user has notifications disabled.

## Test plan

- [ ] Fresh install on Android 13+ device → first launch is silent (no permission prompt).
- [ ] Open the schedule, tap the favorite icon on a talk whose start is ≥10 minutes in the future → system permission dialog appears.
- [ ] Grant the permission, lock the device, wait → reminder fires at T-10 even after Doze kicks in.
- [ ] Unfavorite the talk → no reminder fires.
- [ ] Deny the permission, favorite a talk → DB favorite still toggles, no crash, no notification.
- [ ] Open system settings → app → notifications → channel appears as "Talk reminders" / "Rappels de talks" depending on locale.
- [ ] Same flow on an Android 12 device (API 32) and an Android <13 device → still works without prompts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)