### PR TITLE
Add partner quiz backend (ingestion, codes, scoring & leaderboard)

### DIFF
--- a/backend/src/main/java/com/paligot/confily/backend/Server.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/Server.kt
@@ -11,6 +11,7 @@ import com.paligot.confily.backend.map.infrastructure.api.registerMapRoutes
 import com.paligot.confily.backend.menus.infrastructure.api.registerAdminMenuRoutes
 import com.paligot.confily.backend.partners.infrastructure.api.registerPartnersRoutes
 import com.paligot.confily.backend.planning.infrastructure.api.registerPlanningRoutes
+import com.paligot.confily.backend.quiz.infrastructure.api.registerQuizRoutes
 import com.paligot.confily.backend.sessions.infrastructure.api.registerAdminSessionVoteRoutes
 import com.paligot.confily.backend.sessions.infrastructure.api.registerAdminSessionsRoutes
 import com.paligot.confily.backend.sessions.infrastructure.api.registerSessionVoteRoutes
@@ -129,6 +130,7 @@ private fun Application.routing() {
             registerPartnersRoutes()
             registerMapRoutes()
             registerSessionVoteRoutes()
+            registerQuizRoutes()
             // Third parties
             registerOpenfeedackRoutes()
             registerBilletWebRoutes()

--- a/backend/src/main/java/com/paligot/confily/backend/internals/infrastructure/exposed/DatabaseFactory.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/internals/infrastructure/exposed/DatabaseFactory.kt
@@ -29,6 +29,11 @@ import com.paligot.confily.backend.partners.infrastructure.exposed.SponsoringTyp
 import com.paligot.confily.backend.qanda.infrastructure.exposed.QAndAAcronymsTable
 import com.paligot.confily.backend.qanda.infrastructure.exposed.QAndAActionsTable
 import com.paligot.confily.backend.qanda.infrastructure.exposed.QAndATable
+import com.paligot.confily.backend.quiz.infrastructure.exposed.QuizAnswersTable
+import com.paligot.confily.backend.quiz.infrastructure.exposed.QuizPlayersTable
+import com.paligot.confily.backend.quiz.infrastructure.exposed.QuizQuestionsTable
+import com.paligot.confily.backend.quiz.infrastructure.exposed.QuizSubmissionAnswersTable
+import com.paligot.confily.backend.quiz.infrastructure.exposed.QuizSubmissionsTable
 import com.paligot.confily.backend.schedules.infrastructure.exposed.SchedulesTable
 import com.paligot.confily.backend.sessions.infrastructure.exposed.EventSessionTracksTable
 import com.paligot.confily.backend.sessions.infrastructure.exposed.EventSessionsTable
@@ -84,6 +89,11 @@ object DatabaseFactory {
         QAndATable,
         QAndAActionsTable,
         QAndAAcronymsTable,
+        QuizQuestionsTable,
+        QuizAnswersTable,
+        QuizPlayersTable,
+        QuizSubmissionsTable,
+        QuizSubmissionAnswersTable,
         AddressesTable,
         IntegrationsTable,
         BilletWebIntegrationsTable,

--- a/backend/src/main/java/com/paligot/confily/backend/internals/infrastructure/exposed/migrations/MigrationRegistry.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/internals/infrastructure/exposed/migrations/MigrationRegistry.kt
@@ -2,10 +2,12 @@ package com.paligot.confily.backend.internals.infrastructure.exposed.migrations
 
 import com.paligot.confily.backend.internals.infrastructure.exposed.migrations.versions.AddActivitiesExternalProviderMigration
 import com.paligot.confily.backend.internals.infrastructure.exposed.migrations.versions.AddEventTimezoneMigration
+import com.paligot.confily.backend.internals.infrastructure.exposed.migrations.versions.AddPartnerQuizCodeMigration
 
 object MigrationRegistry {
     val allMigrations: List<Migration> = listOf(
         AddActivitiesExternalProviderMigration,
-        AddEventTimezoneMigration
+        AddEventTimezoneMigration,
+        AddPartnerQuizCodeMigration
     )
 }

--- a/backend/src/main/java/com/paligot/confily/backend/internals/infrastructure/exposed/migrations/versions/AddPartnerQuizCodeMigration.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/internals/infrastructure/exposed/migrations/versions/AddPartnerQuizCodeMigration.kt
@@ -1,0 +1,14 @@
+package com.paligot.confily.backend.internals.infrastructure.exposed.migrations.versions
+
+import com.paligot.confily.backend.internals.infrastructure.exposed.migrations.Migration
+import com.paligot.confily.backend.partners.infrastructure.exposed.PartnersTable
+import org.jetbrains.exposed.sql.SchemaUtils
+
+object AddPartnerQuizCodeMigration : Migration {
+    override val id = "20260601_add_partner_quiz_code"
+    override val description = "Add quiz_code column to partners table for the partner quiz feature"
+
+    override fun up() {
+        SchemaUtils.createMissingTablesAndColumns(PartnersTable)
+    }
+}

--- a/backend/src/main/java/com/paligot/confily/backend/partners/infrastructure/exposed/PartnerEntity.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/partners/infrastructure/exposed/PartnerEntity.kt
@@ -29,6 +29,10 @@ class PartnerEntity(id: EntityID<UUID>) : UUIDEntity(id) {
             val providerOp = PartnersTable.externalProvider eq provider
             eventOp and externalIdOp and providerOp
         }.firstOrNull()
+
+        fun findByQuizCode(eventId: UUID, code: String): PartnerEntity? = this.find {
+            (PartnersTable.eventId eq eventId) and (PartnersTable.quizCode eq code)
+        }.firstOrNull()
     }
 
     var eventId by PartnersTable.eventId
@@ -41,6 +45,7 @@ class PartnerEntity(id: EntityID<UUID>) : UUIDEntity(id) {
     var mediaPng500 by PartnersTable.mediaPng500
     var mediaPng1000 by PartnersTable.mediaPng1000
     var videoUrl by PartnersTable.videoUrl
+    var quizCode by PartnersTable.quizCode
     var addressId by PartnersTable.addressId
     var address by AddressEntity.Companion optionalReferencedOn PartnersTable.addressId
     var externalId by PartnersTable.externalId

--- a/backend/src/main/java/com/paligot/confily/backend/partners/infrastructure/exposed/PartnersTable.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/partners/infrastructure/exposed/PartnersTable.kt
@@ -23,6 +23,7 @@ object PartnersTable : UUIDTable("partners") {
     val mediaPng500 = text("media_png_500").nullable()
     val mediaPng1000 = text("media_png_1000").nullable()
     val videoUrl = text("video_url").nullable()
+    val quizCode = varchar("quiz_code", 4).nullable()
     val addressId = reference("address_id", AddressesTable, onDelete = ReferenceOption.SET_NULL).nullable()
     val externalId = varchar("external_id", 255).nullable()
     val externalProvider = enumeration<IntegrationProvider>("external_provider").nullable()
@@ -33,6 +34,7 @@ object PartnersTable : UUIDTable("partners") {
         index(isUnique = false, eventId)
         index(isUnique = false, eventId, name)
         uniqueIndex(eventId, externalId, externalProvider)
+        uniqueIndex(eventId, quizCode)
     }
 
     fun deleteDiff(

--- a/backend/src/main/java/com/paligot/confily/backend/quiz/application/DeviceIdHasher.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/quiz/application/DeviceIdHasher.kt
@@ -1,0 +1,24 @@
+package com.paligot.confily.backend.quiz.application
+
+import com.paligot.confily.backend.internals.infrastructure.system.SystemEnv
+import java.util.HexFormat
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * Turns a raw device identifier into a deterministic, keyed hash before it is persisted.
+ *
+ * The raw device id never touches the database, so anyone inspecting the storage cannot
+ * trace a row back to a physical device. Hashing is keyed (HMAC) and salted so the device
+ * id space cannot be brute-forced from a database dump alone, and deterministic so that the
+ * unique index and device lookups keep working on the stored value.
+ */
+object DeviceIdHasher {
+    private const val ALGORITHM = "HmacSHA256"
+
+    fun hash(deviceId: String): String {
+        val mac = Mac.getInstance(ALGORITHM)
+        mac.init(SecretKeySpec(SystemEnv.Crypto.key.toByteArray(), ALGORITHM))
+        return HexFormat.of().formatHex(mac.doFinal("${SystemEnv.Crypto.salt}$deviceId".toByteArray()))
+    }
+}

--- a/backend/src/main/java/com/paligot/confily/backend/quiz/application/QuizCodeGenerator.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/quiz/application/QuizCodeGenerator.kt
@@ -1,0 +1,12 @@
+package com.paligot.confily.backend.quiz.application
+
+import kotlin.random.Random
+
+object QuizCodeGenerator {
+    // Uppercase letters excluding I and O to avoid confusion with 1 and 0.
+    private const val ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ"
+    private const val LENGTH = 4
+
+    fun generate(random: Random = Random.Default): String =
+        (1..LENGTH).map { ALPHABET[random.nextInt(ALPHABET.length)] }.joinToString("")
+}

--- a/backend/src/main/java/com/paligot/confily/backend/quiz/application/QuizRepositoryExposed.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/quiz/application/QuizRepositoryExposed.kt
@@ -1,0 +1,47 @@
+package com.paligot.confily.backend.quiz.application
+
+import com.paligot.confily.backend.events.infrastructure.exposed.EventEntity
+import com.paligot.confily.backend.quiz.domain.QuizRepository
+import com.paligot.confily.backend.quiz.infrastructure.exposed.QuizPlayerEntity
+import com.paligot.confily.models.LeaderboardEntry
+import com.paligot.confily.models.QuizQuestion
+import com.paligot.confily.models.QuizSubmissionResult
+import com.paligot.confily.models.inputs.QuizPlayerInput
+import com.paligot.confily.models.inputs.QuizSubmissionInput
+import kotlinx.datetime.Clock
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.transactions.transaction
+import java.util.UUID
+
+class QuizRepositoryExposed(private val database: Database) : QuizRepository {
+
+    override suspend fun registerPlayer(eventId: String, input: QuizPlayerInput): String {
+        val eventUuid = UUID.fromString(eventId)
+        return transaction(db = database) {
+            val event = EventEntity[eventUuid]
+            val existing = QuizPlayerEntity.findByDevice(eventUuid, input.deviceId)
+            val player = if (existing != null) {
+                existing.username = input.username
+                existing.updatedAt = Clock.System.now()
+                existing
+            } else {
+                QuizPlayerEntity.new {
+                    this.event = event
+                    this.deviceId = input.deviceId
+                    this.username = input.username
+                }
+            }
+            player.id.value.toString()
+        }
+    }
+
+    override suspend fun questionsByCode(eventId: String, code: String): List<QuizQuestion> = TODO()
+
+    override suspend fun submit(
+        eventId: String,
+        code: String,
+        input: QuizSubmissionInput
+    ): QuizSubmissionResult = TODO()
+
+    override suspend fun leaderboard(eventId: String): List<LeaderboardEntry> = TODO()
+}

--- a/backend/src/main/java/com/paligot/confily/backend/quiz/application/QuizRepositoryExposed.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/quiz/application/QuizRepositoryExposed.kt
@@ -32,9 +32,10 @@ class QuizRepositoryExposed(private val database: Database) : QuizRepository {
 
     override suspend fun registerPlayer(eventId: String, input: QuizPlayerInput): String {
         val eventUuid = UUID.fromString(eventId)
+        val deviceHash = DeviceIdHasher.hash(input.deviceId)
         return transaction(db = database) {
             val event = EventEntity[eventUuid]
-            val existing = QuizPlayerEntity.findByDevice(eventUuid, input.deviceId)
+            val existing = QuizPlayerEntity.findByDevice(eventUuid, deviceHash)
             val player = if (existing != null) {
                 existing.username = input.username
                 existing.updatedAt = Clock.System.now()
@@ -42,7 +43,7 @@ class QuizRepositoryExposed(private val database: Database) : QuizRepository {
             } else {
                 QuizPlayerEntity.new {
                     this.event = event
-                    this.deviceId = input.deviceId
+                    this.deviceId = deviceHash
                     this.username = input.username
                 }
             }
@@ -72,11 +73,12 @@ class QuizRepositoryExposed(private val database: Database) : QuizRepository {
         input: QuizSubmissionInput
     ): QuizSubmissionResult {
         val eventUuid = UUID.fromString(eventId)
+        val deviceHash = DeviceIdHasher.hash(input.deviceId)
         return transaction(db = database) {
             val partner = PartnerEntity.findByQuizCode(eventUuid, code)
                 ?: throw NotFoundException("No partner found for code $code")
-            val player = QuizPlayerEntity.findByDevice(eventUuid, input.deviceId)
-                ?: throw NotFoundException("Player not registered for device ${input.deviceId}")
+            val player = QuizPlayerEntity.findByDevice(eventUuid, deviceHash)
+                ?: throw NotFoundException("Player not registered for this device")
             val alreadySubmitted = QuizSubmissionEntity
                 .findByPlayerAndPartner(player.id.value, partner.id.value)
             if (alreadySubmitted != null) {

--- a/backend/src/main/java/com/paligot/confily/backend/quiz/application/QuizRepositoryExposed.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/quiz/application/QuizRepositoryExposed.kt
@@ -1,15 +1,30 @@
 package com.paligot.confily.backend.quiz.application
 
+import com.paligot.confily.backend.ConflictException
+import com.paligot.confily.backend.NotFoundException
 import com.paligot.confily.backend.events.infrastructure.exposed.EventEntity
+import com.paligot.confily.backend.partners.infrastructure.exposed.PartnerEntity
 import com.paligot.confily.backend.quiz.domain.QuizRepository
+import com.paligot.confily.backend.quiz.infrastructure.exposed.QuizAnswerEntity
+import com.paligot.confily.backend.quiz.infrastructure.exposed.QuizAnswersTable
 import com.paligot.confily.backend.quiz.infrastructure.exposed.QuizPlayerEntity
+import com.paligot.confily.backend.quiz.infrastructure.exposed.QuizQuestionEntity
+import com.paligot.confily.backend.quiz.infrastructure.exposed.QuizQuestionsTable
+import com.paligot.confily.backend.quiz.infrastructure.exposed.QuizSubmissionAnswerEntity
+import com.paligot.confily.backend.quiz.infrastructure.exposed.QuizSubmissionEntity
+import com.paligot.confily.backend.quiz.infrastructure.exposed.toModel
+import com.paligot.confily.backend.quiz.infrastructure.exposed.toOption
 import com.paligot.confily.models.LeaderboardEntry
+import com.paligot.confily.models.QuizAnsweredQuestion
 import com.paligot.confily.models.QuizQuestion
 import com.paligot.confily.models.QuizSubmissionResult
 import com.paligot.confily.models.inputs.QuizPlayerInput
 import com.paligot.confily.models.inputs.QuizSubmissionInput
 import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.SortOrder
 import org.jetbrains.exposed.sql.transactions.transaction
 import java.util.UUID
 
@@ -35,7 +50,21 @@ class QuizRepositoryExposed(private val database: Database) : QuizRepository {
         }
     }
 
-    override suspend fun questionsByCode(eventId: String, code: String): List<QuizQuestion> = TODO()
+    override suspend fun questionsByCode(eventId: String, code: String): List<QuizQuestion> {
+        val eventUuid = UUID.fromString(eventId)
+        return transaction(db = database) {
+            val partner = PartnerEntity.findByQuizCode(eventUuid, code)
+                ?: throw NotFoundException("No partner found for code $code")
+            QuizQuestionEntity.findByPartner(partner.id.value)
+                .orderBy(QuizQuestionsTable.displayOrder to SortOrder.ASC)
+                .map { question ->
+                    val options = QuizAnswerEntity.findByQuestion(question.id.value)
+                        .orderBy(QuizAnswersTable.displayOrder to SortOrder.ASC)
+                        .map { it.toOption() }
+                    question.toModel(options)
+                }
+        }
+    }
 
     override suspend fun submit(
         eventId: String,

--- a/backend/src/main/java/com/paligot/confily/backend/quiz/application/QuizRepositoryExposed.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/quiz/application/QuizRepositoryExposed.kt
@@ -70,7 +70,71 @@ class QuizRepositoryExposed(private val database: Database) : QuizRepository {
         eventId: String,
         code: String,
         input: QuizSubmissionInput
-    ): QuizSubmissionResult = TODO()
+    ): QuizSubmissionResult {
+        val eventUuid = UUID.fromString(eventId)
+        return transaction(db = database) {
+            val partner = PartnerEntity.findByQuizCode(eventUuid, code)
+                ?: throw NotFoundException("No partner found for code $code")
+            val player = QuizPlayerEntity.findByDevice(eventUuid, input.deviceId)
+                ?: throw NotFoundException("Player not registered for device ${input.deviceId}")
+            val alreadySubmitted = QuizSubmissionEntity
+                .findByPlayerAndPartner(player.id.value, partner.id.value)
+            if (alreadySubmitted != null) {
+                throw ConflictException("Answers already submitted for this partner")
+            }
+
+            val chosenByQuestion = input.answers
+                .associate { UUID.fromString(it.questionId) to UUID.fromString(it.answerId) }
+            val questions = QuizQuestionEntity.findByPartner(partner.id.value).toList()
+
+            val graded = questions.map { question ->
+                val correct = QuizAnswerEntity.findByQuestion(question.id.value)
+                    .first { it.isCorrect }
+                val chosen = chosenByQuestion[question.id.value]
+                val isCorrect = chosen != null && chosen == correct.id.value
+                GradedAnswer(question.id.value, chosen, correct.id.value, isCorrect)
+            }
+            val correctCount = graded.count { it.isCorrect }
+
+            val submission = QuizSubmissionEntity.new {
+                this.event = partner.event
+                this.player = player
+                this.partner = partner
+                this.correctCount = correctCount
+                this.totalCount = questions.size
+            }
+            graded.forEach { answer ->
+                if (answer.chosenAnswerId != null) {
+                    QuizSubmissionAnswerEntity.new {
+                        this.submission = submission
+                        this.questionId = EntityID(answer.questionId, QuizQuestionsTable)
+                        this.chosenAnswerId = EntityID(answer.chosenAnswerId, QuizAnswersTable)
+                        this.isCorrect = answer.isCorrect
+                    }
+                }
+            }
+
+            QuizSubmissionResult(
+                correctCount = correctCount,
+                totalCount = questions.size,
+                perQuestion = graded.map { answer ->
+                    QuizAnsweredQuestion(
+                        questionId = answer.questionId.toString(),
+                        chosenAnswerId = answer.chosenAnswerId?.toString(),
+                        correctAnswerId = answer.correctAnswerId.toString(),
+                        isCorrect = answer.isCorrect
+                    )
+                }
+            )
+        }
+    }
 
     override suspend fun leaderboard(eventId: String): List<LeaderboardEntry> = TODO()
+
+    private data class GradedAnswer(
+        val questionId: UUID,
+        val chosenAnswerId: UUID?,
+        val correctAnswerId: UUID,
+        val isCorrect: Boolean
+    )
 }

--- a/backend/src/main/java/com/paligot/confily/backend/quiz/application/QuizRepositoryExposed.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/quiz/application/QuizRepositoryExposed.kt
@@ -129,12 +129,35 @@ class QuizRepositoryExposed(private val database: Database) : QuizRepository {
         }
     }
 
-    override suspend fun leaderboard(eventId: String): List<LeaderboardEntry> = TODO()
+    override suspend fun leaderboard(eventId: String): List<LeaderboardEntry> {
+        val eventUuid = UUID.fromString(eventId)
+        return transaction(db = database) {
+            QuizSubmissionEntity.findByEvent(eventUuid)
+                .groupBy { it.playerId.value }
+                .map { (playerId, submissions) ->
+                    PlayerScore(
+                        username = QuizPlayerEntity[playerId].username,
+                        score = submissions.sumOf { it.correctCount },
+                        lastSubmittedAt = submissions.maxOf { it.submittedAt }
+                    )
+                }
+                .sortedWith(compareByDescending<PlayerScore> { it.score }.thenBy { it.lastSubmittedAt })
+                .mapIndexed { index, score ->
+                    LeaderboardEntry(rank = index + 1, username = score.username, score = score.score)
+                }
+        }
+    }
 
     private data class GradedAnswer(
         val questionId: UUID,
         val chosenAnswerId: UUID?,
         val correctAnswerId: UUID,
         val isCorrect: Boolean
+    )
+
+    private data class PlayerScore(
+        val username: String,
+        val score: Int,
+        val lastSubmittedAt: Instant
     )
 }

--- a/backend/src/main/java/com/paligot/confily/backend/quiz/domain/QuizRepository.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/quiz/domain/QuizRepository.kt
@@ -1,0 +1,14 @@
+package com.paligot.confily.backend.quiz.domain
+
+import com.paligot.confily.models.LeaderboardEntry
+import com.paligot.confily.models.QuizQuestion
+import com.paligot.confily.models.QuizSubmissionResult
+import com.paligot.confily.models.inputs.QuizPlayerInput
+import com.paligot.confily.models.inputs.QuizSubmissionInput
+
+interface QuizRepository {
+    suspend fun registerPlayer(eventId: String, input: QuizPlayerInput): String
+    suspend fun questionsByCode(eventId: String, code: String): List<QuizQuestion>
+    suspend fun submit(eventId: String, code: String, input: QuizSubmissionInput): QuizSubmissionResult
+    suspend fun leaderboard(eventId: String): List<LeaderboardEntry>
+}

--- a/backend/src/main/java/com/paligot/confily/backend/quiz/infrastructure/api/QuizRouting.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/quiz/infrastructure/api/QuizRouting.kt
@@ -1,0 +1,41 @@
+package com.paligot.confily.backend.quiz.infrastructure.api
+
+import com.paligot.confily.backend.internals.infrastructure.ktor.http.Identifier
+import com.paligot.confily.backend.quiz.infrastructure.factory.QuizModule.quizRepository
+import com.paligot.confily.backend.receiveValidated
+import com.paligot.confily.models.inputs.QuizPlayerInput
+import com.paligot.confily.models.inputs.QuizSubmissionInput
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+
+fun Route.registerQuizRoutes() {
+    val repository = quizRepository
+
+    route("/quiz") {
+        post("/players") {
+            val eventId = call.parameters["eventId"]!!
+            val input = call.receiveValidated<QuizPlayerInput>()
+            val playerId = repository.registerPlayer(eventId, input)
+            call.respond(status = HttpStatusCode.Created, message = Identifier(playerId))
+        }
+        get("/partners/{code}") {
+            val eventId = call.parameters["eventId"]!!
+            val code = call.parameters["code"]!!
+            call.respond(status = HttpStatusCode.OK, message = repository.questionsByCode(eventId, code))
+        }
+        post("/partners/{code}/submit") {
+            val eventId = call.parameters["eventId"]!!
+            val code = call.parameters["code"]!!
+            val input = call.receiveValidated<QuizSubmissionInput>()
+            call.respond(status = HttpStatusCode.Created, message = repository.submit(eventId, code, input))
+        }
+        get("/leaderboard") {
+            val eventId = call.parameters["eventId"]!!
+            call.respond(status = HttpStatusCode.OK, message = repository.leaderboard(eventId))
+        }
+    }
+}

--- a/backend/src/main/java/com/paligot/confily/backend/quiz/infrastructure/exposed/QuizAnswerEntity.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/quiz/infrastructure/exposed/QuizAnswerEntity.kt
@@ -1,15 +1,27 @@
 package com.paligot.confily.backend.quiz.infrastructure.exposed
 
+import com.paligot.confily.backend.integrations.domain.IntegrationProvider
 import org.jetbrains.exposed.dao.UUIDEntity
 import org.jetbrains.exposed.dao.UUIDEntityClass
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.sql.SizedIterable
+import org.jetbrains.exposed.sql.and
 import java.util.UUID
 
 class QuizAnswerEntity(id: EntityID<UUID>) : UUIDEntity(id) {
     companion object : UUIDEntityClass<QuizAnswerEntity>(QuizAnswersTable) {
         fun findByQuestion(questionId: UUID): SizedIterable<QuizAnswerEntity> = this
             .find { QuizAnswersTable.questionId eq questionId }
+
+        fun findByExternalId(
+            questionId: UUID,
+            externalId: String,
+            provider: IntegrationProvider
+        ): QuizAnswerEntity? = this.find {
+            (QuizAnswersTable.questionId eq questionId) and
+                (QuizAnswersTable.externalId eq externalId) and
+                (QuizAnswersTable.externalProvider eq provider)
+        }.firstOrNull()
     }
 
     var questionId by QuizAnswersTable.questionId
@@ -18,5 +30,6 @@ class QuizAnswerEntity(id: EntityID<UUID>) : UUIDEntity(id) {
     var isCorrect by QuizAnswersTable.isCorrect
     var displayOrder by QuizAnswersTable.displayOrder
     var externalId by QuizAnswersTable.externalId
+    var externalProvider by QuizAnswersTable.externalProvider
     var createdAt by QuizAnswersTable.createdAt
 }

--- a/backend/src/main/java/com/paligot/confily/backend/quiz/infrastructure/exposed/QuizAnswerEntity.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/quiz/infrastructure/exposed/QuizAnswerEntity.kt
@@ -1,0 +1,22 @@
+package com.paligot.confily.backend.quiz.infrastructure.exposed
+
+import org.jetbrains.exposed.dao.UUIDEntity
+import org.jetbrains.exposed.dao.UUIDEntityClass
+import org.jetbrains.exposed.dao.id.EntityID
+import org.jetbrains.exposed.sql.SizedIterable
+import java.util.UUID
+
+class QuizAnswerEntity(id: EntityID<UUID>) : UUIDEntity(id) {
+    companion object : UUIDEntityClass<QuizAnswerEntity>(QuizAnswersTable) {
+        fun findByQuestion(questionId: UUID): SizedIterable<QuizAnswerEntity> = this
+            .find { QuizAnswersTable.questionId eq questionId }
+    }
+
+    var questionId by QuizAnswersTable.questionId
+    var question by QuizQuestionEntity referencedOn QuizAnswersTable.questionId
+    var answer by QuizAnswersTable.answer
+    var isCorrect by QuizAnswersTable.isCorrect
+    var displayOrder by QuizAnswersTable.displayOrder
+    var externalId by QuizAnswersTable.externalId
+    var createdAt by QuizAnswersTable.createdAt
+}

--- a/backend/src/main/java/com/paligot/confily/backend/quiz/infrastructure/exposed/QuizAnswersTable.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/quiz/infrastructure/exposed/QuizAnswersTable.kt
@@ -1,0 +1,19 @@
+package com.paligot.confily.backend.quiz.infrastructure.exposed
+
+import kotlinx.datetime.Clock
+import org.jetbrains.exposed.dao.id.UUIDTable
+import org.jetbrains.exposed.sql.ReferenceOption
+import org.jetbrains.exposed.sql.kotlin.datetime.timestamp
+
+object QuizAnswersTable : UUIDTable("quiz_answers") {
+    val questionId = reference("question_id", QuizQuestionsTable, onDelete = ReferenceOption.CASCADE)
+    val answer = text("answer")
+    val isCorrect = bool("is_correct").default(false)
+    val displayOrder = integer("display_order").default(0)
+    val externalId = varchar("external_id", 255).nullable()
+    val createdAt = timestamp("created_at").clientDefault { Clock.System.now() }
+
+    init {
+        index(isUnique = false, questionId)
+    }
+}

--- a/backend/src/main/java/com/paligot/confily/backend/quiz/infrastructure/exposed/QuizAnswersTable.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/quiz/infrastructure/exposed/QuizAnswersTable.kt
@@ -1,5 +1,6 @@
 package com.paligot.confily.backend.quiz.infrastructure.exposed
 
+import com.paligot.confily.backend.integrations.domain.IntegrationProvider
 import kotlinx.datetime.Clock
 import org.jetbrains.exposed.dao.id.UUIDTable
 import org.jetbrains.exposed.sql.ReferenceOption
@@ -11,9 +12,11 @@ object QuizAnswersTable : UUIDTable("quiz_answers") {
     val isCorrect = bool("is_correct").default(false)
     val displayOrder = integer("display_order").default(0)
     val externalId = varchar("external_id", 255).nullable()
+    val externalProvider = enumeration<IntegrationProvider>("external_provider").nullable()
     val createdAt = timestamp("created_at").clientDefault { Clock.System.now() }
 
     init {
         index(isUnique = false, questionId)
+        uniqueIndex(questionId, externalId, externalProvider)
     }
 }

--- a/backend/src/main/java/com/paligot/confily/backend/quiz/infrastructure/exposed/QuizMappers.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/quiz/infrastructure/exposed/QuizMappers.kt
@@ -1,0 +1,17 @@
+package com.paligot.confily.backend.quiz.infrastructure.exposed
+
+import com.paligot.confily.models.QuizAnswerOption
+import com.paligot.confily.models.QuizQuestion
+
+fun QuizAnswerEntity.toOption(): QuizAnswerOption = QuizAnswerOption(
+    id = this.id.value.toString(),
+    label = this.answer,
+    order = this.displayOrder
+)
+
+fun QuizQuestionEntity.toModel(options: List<QuizAnswerOption>): QuizQuestion = QuizQuestion(
+    id = this.id.value.toString(),
+    order = this.displayOrder,
+    question = this.question,
+    options = options
+)

--- a/backend/src/main/java/com/paligot/confily/backend/quiz/infrastructure/exposed/QuizPlayerEntity.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/quiz/infrastructure/exposed/QuizPlayerEntity.kt
@@ -1,0 +1,23 @@
+package com.paligot.confily.backend.quiz.infrastructure.exposed
+
+import com.paligot.confily.backend.events.infrastructure.exposed.EventEntity
+import org.jetbrains.exposed.dao.UUIDEntity
+import org.jetbrains.exposed.dao.UUIDEntityClass
+import org.jetbrains.exposed.dao.id.EntityID
+import org.jetbrains.exposed.sql.and
+import java.util.UUID
+
+class QuizPlayerEntity(id: EntityID<UUID>) : UUIDEntity(id) {
+    companion object : UUIDEntityClass<QuizPlayerEntity>(QuizPlayersTable) {
+        fun findByDevice(eventId: UUID, deviceId: String): QuizPlayerEntity? = this.find {
+            (QuizPlayersTable.eventId eq eventId) and (QuizPlayersTable.deviceId eq deviceId)
+        }.firstOrNull()
+    }
+
+    var eventId by QuizPlayersTable.eventId
+    var event by EventEntity.Companion referencedOn QuizPlayersTable.eventId
+    var deviceId by QuizPlayersTable.deviceId
+    var username by QuizPlayersTable.username
+    var createdAt by QuizPlayersTable.createdAt
+    var updatedAt by QuizPlayersTable.updatedAt
+}

--- a/backend/src/main/java/com/paligot/confily/backend/quiz/infrastructure/exposed/QuizPlayersTable.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/quiz/infrastructure/exposed/QuizPlayersTable.kt
@@ -1,0 +1,19 @@
+package com.paligot.confily.backend.quiz.infrastructure.exposed
+
+import com.paligot.confily.backend.events.infrastructure.exposed.EventsTable
+import kotlinx.datetime.Clock
+import org.jetbrains.exposed.dao.id.UUIDTable
+import org.jetbrains.exposed.sql.ReferenceOption
+import org.jetbrains.exposed.sql.kotlin.datetime.timestamp
+
+object QuizPlayersTable : UUIDTable("quiz_players") {
+    val eventId = reference("event_id", EventsTable, onDelete = ReferenceOption.CASCADE)
+    val deviceId = varchar("device_id", 255)
+    val username = varchar("username", 255)
+    val createdAt = timestamp("created_at").clientDefault { Clock.System.now() }
+    val updatedAt = timestamp("updated_at").clientDefault { Clock.System.now() }
+
+    init {
+        uniqueIndex(eventId, deviceId)
+    }
+}

--- a/backend/src/main/java/com/paligot/confily/backend/quiz/infrastructure/exposed/QuizQuestionEntity.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/quiz/infrastructure/exposed/QuizQuestionEntity.kt
@@ -1,0 +1,39 @@
+package com.paligot.confily.backend.quiz.infrastructure.exposed
+
+import com.paligot.confily.backend.events.infrastructure.exposed.EventEntity
+import com.paligot.confily.backend.integrations.domain.IntegrationProvider
+import com.paligot.confily.backend.partners.infrastructure.exposed.PartnerEntity
+import org.jetbrains.exposed.dao.UUIDEntity
+import org.jetbrains.exposed.dao.UUIDEntityClass
+import org.jetbrains.exposed.dao.id.EntityID
+import org.jetbrains.exposed.sql.SizedIterable
+import org.jetbrains.exposed.sql.and
+import java.util.UUID
+
+class QuizQuestionEntity(id: EntityID<UUID>) : UUIDEntity(id) {
+    companion object : UUIDEntityClass<QuizQuestionEntity>(QuizQuestionsTable) {
+        fun findByPartner(partnerId: UUID): SizedIterable<QuizQuestionEntity> = this
+            .find { QuizQuestionsTable.partnerId eq partnerId }
+
+        fun findByExternalId(
+            eventId: UUID,
+            externalId: String,
+            provider: IntegrationProvider
+        ): QuizQuestionEntity? = this.find {
+            (QuizQuestionsTable.eventId eq eventId) and
+                (QuizQuestionsTable.externalId eq externalId) and
+                (QuizQuestionsTable.externalProvider eq provider)
+        }.firstOrNull()
+    }
+
+    var eventId by QuizQuestionsTable.eventId
+    var event by EventEntity.Companion referencedOn QuizQuestionsTable.eventId
+    var partnerId by QuizQuestionsTable.partnerId
+    var partner by PartnerEntity.Companion referencedOn QuizQuestionsTable.partnerId
+    var displayOrder by QuizQuestionsTable.displayOrder
+    var question by QuizQuestionsTable.question
+    var externalId by QuizQuestionsTable.externalId
+    var externalProvider by QuizQuestionsTable.externalProvider
+    var createdAt by QuizQuestionsTable.createdAt
+    var updatedAt by QuizQuestionsTable.updatedAt
+}

--- a/backend/src/main/java/com/paligot/confily/backend/quiz/infrastructure/exposed/QuizQuestionsTable.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/quiz/infrastructure/exposed/QuizQuestionsTable.kt
@@ -1,0 +1,26 @@
+package com.paligot.confily.backend.quiz.infrastructure.exposed
+
+import com.paligot.confily.backend.events.infrastructure.exposed.EventsTable
+import com.paligot.confily.backend.integrations.domain.IntegrationProvider
+import com.paligot.confily.backend.partners.infrastructure.exposed.PartnersTable
+import kotlinx.datetime.Clock
+import org.jetbrains.exposed.dao.id.UUIDTable
+import org.jetbrains.exposed.sql.ReferenceOption
+import org.jetbrains.exposed.sql.kotlin.datetime.timestamp
+
+object QuizQuestionsTable : UUIDTable("quiz_questions") {
+    val eventId = reference("event_id", EventsTable, onDelete = ReferenceOption.CASCADE)
+    val partnerId = reference("partner_id", PartnersTable, onDelete = ReferenceOption.CASCADE)
+    val displayOrder = integer("display_order").default(0)
+    val question = text("question")
+    val externalId = varchar("external_id", 255).nullable()
+    val externalProvider = enumeration<IntegrationProvider>("external_provider").nullable()
+    val createdAt = timestamp("created_at").clientDefault { Clock.System.now() }
+    val updatedAt = timestamp("updated_at").clientDefault { Clock.System.now() }
+
+    init {
+        index(isUnique = false, partnerId)
+        index(isUnique = false, eventId)
+        uniqueIndex(eventId, externalId, externalProvider)
+    }
+}

--- a/backend/src/main/java/com/paligot/confily/backend/quiz/infrastructure/exposed/QuizSubmissionAnswerEntity.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/quiz/infrastructure/exposed/QuizSubmissionAnswerEntity.kt
@@ -1,0 +1,16 @@
+package com.paligot.confily.backend.quiz.infrastructure.exposed
+
+import org.jetbrains.exposed.dao.UUIDEntity
+import org.jetbrains.exposed.dao.UUIDEntityClass
+import org.jetbrains.exposed.dao.id.EntityID
+import java.util.UUID
+
+class QuizSubmissionAnswerEntity(id: EntityID<UUID>) : UUIDEntity(id) {
+    companion object : UUIDEntityClass<QuizSubmissionAnswerEntity>(QuizSubmissionAnswersTable)
+
+    var submissionId by QuizSubmissionAnswersTable.submissionId
+    var submission by QuizSubmissionEntity referencedOn QuizSubmissionAnswersTable.submissionId
+    var questionId by QuizSubmissionAnswersTable.questionId
+    var chosenAnswerId by QuizSubmissionAnswersTable.chosenAnswerId
+    var isCorrect by QuizSubmissionAnswersTable.isCorrect
+}

--- a/backend/src/main/java/com/paligot/confily/backend/quiz/infrastructure/exposed/QuizSubmissionAnswersTable.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/quiz/infrastructure/exposed/QuizSubmissionAnswersTable.kt
@@ -1,0 +1,15 @@
+package com.paligot.confily.backend.quiz.infrastructure.exposed
+
+import org.jetbrains.exposed.dao.id.UUIDTable
+import org.jetbrains.exposed.sql.ReferenceOption
+
+object QuizSubmissionAnswersTable : UUIDTable("quiz_submission_answers") {
+    val submissionId = reference("submission_id", QuizSubmissionsTable, onDelete = ReferenceOption.CASCADE)
+    val questionId = reference("question_id", QuizQuestionsTable, onDelete = ReferenceOption.CASCADE)
+    val chosenAnswerId = reference("chosen_answer_id", QuizAnswersTable, onDelete = ReferenceOption.CASCADE)
+    val isCorrect = bool("is_correct")
+
+    init {
+        index(isUnique = false, submissionId)
+    }
+}

--- a/backend/src/main/java/com/paligot/confily/backend/quiz/infrastructure/exposed/QuizSubmissionEntity.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/quiz/infrastructure/exposed/QuizSubmissionEntity.kt
@@ -1,0 +1,31 @@
+package com.paligot.confily.backend.quiz.infrastructure.exposed
+
+import com.paligot.confily.backend.events.infrastructure.exposed.EventEntity
+import com.paligot.confily.backend.partners.infrastructure.exposed.PartnerEntity
+import org.jetbrains.exposed.dao.UUIDEntity
+import org.jetbrains.exposed.dao.UUIDEntityClass
+import org.jetbrains.exposed.dao.id.EntityID
+import org.jetbrains.exposed.sql.SizedIterable
+import org.jetbrains.exposed.sql.and
+import java.util.UUID
+
+class QuizSubmissionEntity(id: EntityID<UUID>) : UUIDEntity(id) {
+    companion object : UUIDEntityClass<QuizSubmissionEntity>(QuizSubmissionsTable) {
+        fun findByEvent(eventId: UUID): SizedIterable<QuizSubmissionEntity> = this
+            .find { QuizSubmissionsTable.eventId eq eventId }
+
+        fun findByPlayerAndPartner(playerId: UUID, partnerId: UUID): QuizSubmissionEntity? = this.find {
+            (QuizSubmissionsTable.playerId eq playerId) and (QuizSubmissionsTable.partnerId eq partnerId)
+        }.firstOrNull()
+    }
+
+    var eventId by QuizSubmissionsTable.eventId
+    var event by EventEntity.Companion referencedOn QuizSubmissionsTable.eventId
+    var playerId by QuizSubmissionsTable.playerId
+    var player by QuizPlayerEntity referencedOn QuizSubmissionsTable.playerId
+    var partnerId by QuizSubmissionsTable.partnerId
+    var partner by PartnerEntity.Companion referencedOn QuizSubmissionsTable.partnerId
+    var correctCount by QuizSubmissionsTable.correctCount
+    var totalCount by QuizSubmissionsTable.totalCount
+    var submittedAt by QuizSubmissionsTable.submittedAt
+}

--- a/backend/src/main/java/com/paligot/confily/backend/quiz/infrastructure/exposed/QuizSubmissionsTable.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/quiz/infrastructure/exposed/QuizSubmissionsTable.kt
@@ -1,0 +1,22 @@
+package com.paligot.confily.backend.quiz.infrastructure.exposed
+
+import com.paligot.confily.backend.events.infrastructure.exposed.EventsTable
+import com.paligot.confily.backend.partners.infrastructure.exposed.PartnersTable
+import kotlinx.datetime.Clock
+import org.jetbrains.exposed.dao.id.UUIDTable
+import org.jetbrains.exposed.sql.ReferenceOption
+import org.jetbrains.exposed.sql.kotlin.datetime.timestamp
+
+object QuizSubmissionsTable : UUIDTable("quiz_submissions") {
+    val eventId = reference("event_id", EventsTable, onDelete = ReferenceOption.CASCADE)
+    val playerId = reference("player_id", QuizPlayersTable, onDelete = ReferenceOption.CASCADE)
+    val partnerId = reference("partner_id", PartnersTable, onDelete = ReferenceOption.CASCADE)
+    val correctCount = integer("correct_count")
+    val totalCount = integer("total_count")
+    val submittedAt = timestamp("submitted_at").clientDefault { Clock.System.now() }
+
+    init {
+        uniqueIndex(playerId, partnerId)
+        index(isUnique = false, eventId)
+    }
+}

--- a/backend/src/main/java/com/paligot/confily/backend/quiz/infrastructure/factory/QuizModule.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/quiz/infrastructure/factory/QuizModule.kt
@@ -1,0 +1,10 @@
+package com.paligot.confily.backend.quiz.infrastructure.factory
+
+import com.paligot.confily.backend.internals.infrastructure.exposed.PostgresModule
+import com.paligot.confily.backend.quiz.application.QuizRepositoryExposed
+
+object QuizModule {
+    val quizRepository by lazy {
+        QuizRepositoryExposed(PostgresModule.database)
+    }
+}

--- a/backend/src/main/java/com/paligot/confily/backend/third/parties/partnersconnect/application/PartnersConnectRepositoryExposed.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/third/parties/partnersconnect/application/PartnersConnectRepositoryExposed.kt
@@ -260,15 +260,28 @@ class PartnersConnectRepositoryExposed(
                     this.externalId = question.id
                     this.externalProvider = IntegrationProvider.PARTNERSCONNECT
                 }
-            QuizAnswersTable.deleteWhere { QuizAnswersTable.questionId eq entity.id.value }
+            val incomingAnswerIds = question.answers.map { it.id }
+            QuizAnswersTable.deleteWhere {
+                (QuizAnswersTable.questionId eq entity.id.value) and
+                    (QuizAnswersTable.externalProvider eq IntegrationProvider.PARTNERSCONNECT) and
+                    (QuizAnswersTable.externalId notInList incomingAnswerIds)
+            }
             question.answers.forEach { answer ->
-                QuizAnswerEntity.new {
-                    this.question = entity
-                    this.answer = answer.answer
-                    this.isCorrect = answer.isCorrect
-                    this.displayOrder = answer.order
-                    this.externalId = answer.id
-                }
+                QuizAnswerEntity
+                    .findByExternalId(entity.id.value, answer.id, IntegrationProvider.PARTNERSCONNECT)
+                    ?.apply {
+                        this.answer = answer.answer
+                        this.isCorrect = answer.isCorrect
+                        this.displayOrder = answer.order
+                    }
+                    ?: QuizAnswerEntity.new {
+                        this.question = entity
+                        this.answer = answer.answer
+                        this.isCorrect = answer.isCorrect
+                        this.displayOrder = answer.order
+                        this.externalId = answer.id
+                        this.externalProvider = IntegrationProvider.PARTNERSCONNECT
+                    }
             }
         }
         if (payload.questions.isNotEmpty() && partner.quizCode == null) {

--- a/backend/src/main/java/com/paligot/confily/backend/third/parties/partnersconnect/application/PartnersConnectRepositoryExposed.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/third/parties/partnersconnect/application/PartnersConnectRepositoryExposed.kt
@@ -17,6 +17,11 @@ import com.paligot.confily.backend.partners.infrastructure.exposed.PartnerSpeake
 import com.paligot.confily.backend.partners.infrastructure.exposed.PartnerSpeakersTable
 import com.paligot.confily.backend.partners.infrastructure.exposed.PartnerSponsorshipsTable
 import com.paligot.confily.backend.partners.infrastructure.exposed.SponsoringTypeEntity
+import com.paligot.confily.backend.quiz.application.QuizCodeGenerator
+import com.paligot.confily.backend.quiz.infrastructure.exposed.QuizAnswerEntity
+import com.paligot.confily.backend.quiz.infrastructure.exposed.QuizAnswersTable
+import com.paligot.confily.backend.quiz.infrastructure.exposed.QuizQuestionEntity
+import com.paligot.confily.backend.quiz.infrastructure.exposed.QuizQuestionsTable
 import com.paligot.confily.backend.speakers.infrastructure.exposed.SpeakerEntity
 import com.paligot.confily.backend.third.parties.partnersconnect.domain.PartnersConnectRepository
 import com.paligot.confily.backend.third.parties.partnersconnect.infrastructure.provider.InvoiceStatus
@@ -24,6 +29,7 @@ import com.paligot.confily.backend.third.parties.partnersconnect.infrastructure.
 import com.paligot.confily.models.SocialType
 import com.paligot.confily.models.mapToSocialType
 import kotlinx.coroutines.coroutineScope
+import kotlinx.datetime.Clock
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toInstant
 import org.jetbrains.exposed.sql.Database
@@ -72,6 +78,7 @@ class PartnersConnectRepositoryExposed(
             upsertJobs(partner, payload)
             upsertActivities(partner, event, payload)
             upsertSpeakers(partner, eventUuid, payload)
+            upsertQuestions(partner, event, payload)
             partner.id.value.toString()
         }
     }
@@ -223,5 +230,63 @@ class PartnersConnectRepositoryExposed(
                 this.speaker = speaker
             }
         }
+    }
+
+    private fun upsertQuestions(
+        partner: PartnerEntity,
+        event: EventEntity,
+        payload: PartnersConnectWebhookPayload
+    ) {
+        val incomingIds = payload.questions.map { it.id }
+        QuizQuestionsTable.deleteWhere {
+            (QuizQuestionsTable.partnerId eq partner.id.value) and
+                (QuizQuestionsTable.externalProvider eq IntegrationProvider.PARTNERSCONNECT) and
+                (QuizQuestionsTable.externalId notInList incomingIds)
+        }
+        payload.questions.forEach { question ->
+            val entity = QuizQuestionEntity
+                .findByExternalId(event.id.value, question.id, IntegrationProvider.PARTNERSCONNECT)
+                ?.apply {
+                    this.partner = partner
+                    this.question = question.question
+                    this.displayOrder = question.order
+                    this.updatedAt = Clock.System.now()
+                }
+                ?: QuizQuestionEntity.new {
+                    this.event = event
+                    this.partner = partner
+                    this.question = question.question
+                    this.displayOrder = question.order
+                    this.externalId = question.id
+                    this.externalProvider = IntegrationProvider.PARTNERSCONNECT
+                }
+            QuizAnswersTable.deleteWhere { QuizAnswersTable.questionId eq entity.id.value }
+            question.answers.forEach { answer ->
+                QuizAnswerEntity.new {
+                    this.question = entity
+                    this.answer = answer.answer
+                    this.isCorrect = answer.isCorrect
+                    this.displayOrder = answer.order
+                    this.externalId = answer.id
+                }
+            }
+        }
+        if (payload.questions.isNotEmpty() && partner.quizCode == null) {
+            partner.quizCode = generateUniqueQuizCode(event.id.value)
+        }
+    }
+
+    private fun generateUniqueQuizCode(eventId: UUID): String {
+        repeat(MAX_QUIZ_CODE_ATTEMPTS) {
+            val candidate = QuizCodeGenerator.generate()
+            if (PartnerEntity.findByQuizCode(eventId, candidate) == null) {
+                return candidate
+            }
+        }
+        throw NotAcceptableException("Could not generate a unique quiz code")
+    }
+
+    companion object {
+        private const val MAX_QUIZ_CODE_ATTEMPTS = 10
     }
 }

--- a/backend/src/main/java/com/paligot/confily/backend/third/parties/partnersconnect/infrastructure/provider/WebhookPayload.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/third/parties/partnersconnect/infrastructure/provider/WebhookPayload.kt
@@ -14,6 +14,7 @@ data class PartnersConnectWebhookPayload(
     val activities: List<BoothActivity>,
     val speakers: List<WebhookSpeaker> = emptyList(),
     val supportVideoUrl: String? = null,
+    val questions: List<WebhookQuestion> = emptyList(),
     val timestamp: String
 )
 
@@ -167,4 +168,21 @@ data class WebhookSpeaker(
     @SerialName("external_id")
     val externalId: String,
     val source: String
+)
+
+@Serializable
+data class WebhookQuestion(
+    val id: String,
+    val question: String,
+    val order: Int = 0,
+    val answers: List<WebhookAnswer> = emptyList()
+)
+
+@Serializable
+data class WebhookAnswer(
+    val id: String,
+    val answer: String,
+    @SerialName("is_correct")
+    val isCorrect: Boolean = false,
+    val order: Int = 0
 )

--- a/backend/src/test/java/com/paligot/confily/backend/quiz/QuizCodeGeneratorTest.kt
+++ b/backend/src/test/java/com/paligot/confily/backend/quiz/QuizCodeGeneratorTest.kt
@@ -1,0 +1,24 @@
+package com.paligot.confily.backend.quiz
+
+import com.paligot.confily.backend.quiz.application.QuizCodeGenerator
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class QuizCodeGeneratorTest {
+    @Test
+    fun `generates a 4-letter code`() {
+        val code = QuizCodeGenerator.generate(Random(42))
+        assertEquals(4, code.length)
+    }
+
+    @Test
+    fun `uses only unambiguous uppercase letters`() {
+        val allowed = "ABCDEFGHJKLMNPQRSTUVWXYZ".toSet()
+        repeat(200) { seed ->
+            val code = QuizCodeGenerator.generate(Random(seed.toLong()))
+            assertTrue(code.all { it in allowed }, "Unexpected char in $code")
+        }
+    }
+}

--- a/backend/src/test/java/com/paligot/confily/backend/quiz/QuizRepositoryExposedTest.kt
+++ b/backend/src/test/java/com/paligot/confily/backend/quiz/QuizRepositoryExposedTest.kt
@@ -1,10 +1,13 @@
 package com.paligot.confily.backend.quiz
 
+import com.paligot.confily.backend.ConflictException
 import com.paligot.confily.backend.NotFoundException
 import com.paligot.confily.backend.internals.infrastructure.exposed.DatabaseFactory
 import com.paligot.confily.backend.quiz.application.QuizRepositoryExposed
 import com.paligot.confily.backend.quiz.infrastructure.exposed.QuizPlayersTable
+import com.paligot.confily.models.inputs.QuizAnswerInput
 import com.paligot.confily.models.inputs.QuizPlayerInput
+import com.paligot.confily.models.inputs.QuizSubmissionInput
 import kotlinx.coroutines.runBlocking
 import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.selectAll
@@ -81,6 +84,76 @@ class QuizRepositoryExposedTest {
         val eventId = QuizTestFixtures.createEvent(database)
         assertFailsWith<NotFoundException> {
             runBlocking { repository.questionsByCode(eventId.toString(), "ZZZZ") }
+        }
+    }
+
+    @Test
+    fun `submit grades answers server-side and returns counts`() = runBlocking {
+        val eventId = QuizTestFixtures.createEvent(database)
+        val partnerId = QuizTestFixtures.createPartner(database, eventId, quizCode = "ABCD")
+        val q1 = QuizTestFixtures.createQuestion(
+            database, eventId, partnerId, "Q1", listOf("right", "wrong"), correctIndex = 0, order = 0
+        )
+        val q2 = QuizTestFixtures.createQuestion(
+            database, eventId, partnerId, "Q2", listOf("wrong", "right"), correctIndex = 1, order = 1
+        )
+        repository.registerPlayer(eventId.toString(), QuizPlayerInput("Alice", "device-1"))
+
+        val q1Correct = QuizTestFixtures.answerIds(database, q1)[0]
+        val q2Wrong = QuizTestFixtures.answerIds(database, q2)[0]
+        val result = repository.submit(
+            eventId.toString(),
+            "ABCD",
+            QuizSubmissionInput(
+                deviceId = "device-1",
+                answers = listOf(
+                    QuizAnswerInput(q1.toString(), q1Correct.toString()),
+                    QuizAnswerInput(q2.toString(), q2Wrong.toString())
+                )
+            )
+        )
+
+        assertEquals(2, result.totalCount)
+        assertEquals(1, result.correctCount)
+        assertEquals(2, result.perQuestion.size)
+        assertEquals(true, result.perQuestion.first { it.questionId == q1.toString() }.isCorrect)
+        assertEquals(false, result.perQuestion.first { it.questionId == q2.toString() }.isCorrect)
+    }
+
+    @Test
+    fun `submit a second time for the same partner is rejected with Conflict`() {
+        val eventId = QuizTestFixtures.createEvent(database)
+        val partnerId = QuizTestFixtures.createPartner(database, eventId, quizCode = "ABCD")
+        val q1 = QuizTestFixtures.createQuestion(
+            database, eventId, partnerId, "Q1", listOf("right", "wrong"), correctIndex = 0
+        )
+        runBlocking { repository.registerPlayer(eventId.toString(), QuizPlayerInput("Alice", "device-1")) }
+        val answer = QuizTestFixtures.answerIds(database, q1)[0]
+        val input = QuizSubmissionInput("device-1", listOf(QuizAnswerInput(q1.toString(), answer.toString())))
+        runBlocking { repository.submit(eventId.toString(), "ABCD", input) }
+
+        assertFailsWith<ConflictException> {
+            runBlocking { repository.submit(eventId.toString(), "ABCD", input) }
+        }
+    }
+
+    @Test
+    fun `submit with an unregistered device is rejected with NotFound`() {
+        val eventId = QuizTestFixtures.createEvent(database)
+        val partnerId = QuizTestFixtures.createPartner(database, eventId, quizCode = "ABCD")
+        val q1 = QuizTestFixtures.createQuestion(
+            database, eventId, partnerId, "Q1", listOf("right", "wrong"), correctIndex = 0
+        )
+        val answer = QuizTestFixtures.answerIds(database, q1)[0]
+
+        assertFailsWith<NotFoundException> {
+            runBlocking {
+                repository.submit(
+                    eventId.toString(),
+                    "ABCD",
+                    QuizSubmissionInput("unknown-device", listOf(QuizAnswerInput(q1.toString(), answer.toString())))
+                )
+            }
         }
     }
 }

--- a/backend/src/test/java/com/paligot/confily/backend/quiz/QuizRepositoryExposedTest.kt
+++ b/backend/src/test/java/com/paligot/confily/backend/quiz/QuizRepositoryExposedTest.kt
@@ -1,0 +1,57 @@
+package com.paligot.confily.backend.quiz
+
+import com.paligot.confily.backend.internals.infrastructure.exposed.DatabaseFactory
+import com.paligot.confily.backend.quiz.application.QuizRepositoryExposed
+import com.paligot.confily.backend.quiz.infrastructure.exposed.QuizPlayersTable
+import com.paligot.confily.models.inputs.QuizPlayerInput
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class QuizRepositoryExposedTest {
+    private lateinit var database: Database
+    private lateinit var repository: QuizRepositoryExposed
+
+    @BeforeTest
+    fun setup() {
+        database = DatabaseFactory.createTestDatabase()
+        repository = QuizRepositoryExposed(database)
+    }
+
+    @Test
+    fun `registerPlayer creates a player and returns its id`() = runBlocking {
+        val eventId = QuizTestFixtures.createEvent(database)
+
+        val playerId = repository.registerPlayer(
+            eventId.toString(),
+            QuizPlayerInput(username = "Alice", deviceId = "device-1")
+        )
+
+        assertTrue(playerId.isNotBlank())
+        val count = transaction(database) { QuizPlayersTable.selectAll().count() }
+        assertEquals(1, count)
+    }
+
+    @Test
+    fun `registerPlayer with same device updates username without duplicating`() = runBlocking {
+        val eventId = QuizTestFixtures.createEvent(database)
+
+        val first = repository.registerPlayer(
+            eventId.toString(),
+            QuizPlayerInput(username = "Alice", deviceId = "device-1")
+        )
+        val second = repository.registerPlayer(
+            eventId.toString(),
+            QuizPlayerInput(username = "Alice Renamed", deviceId = "device-1")
+        )
+
+        assertEquals(first, second)
+        val count = transaction(database) { QuizPlayersTable.selectAll().count() }
+        assertEquals(1, count)
+    }
+}

--- a/backend/src/test/java/com/paligot/confily/backend/quiz/QuizRepositoryExposedTest.kt
+++ b/backend/src/test/java/com/paligot/confily/backend/quiz/QuizRepositoryExposedTest.kt
@@ -3,6 +3,7 @@ package com.paligot.confily.backend.quiz
 import com.paligot.confily.backend.ConflictException
 import com.paligot.confily.backend.NotFoundException
 import com.paligot.confily.backend.internals.infrastructure.exposed.DatabaseFactory
+import com.paligot.confily.backend.quiz.application.DeviceIdHasher
 import com.paligot.confily.backend.quiz.application.QuizRepositoryExposed
 import com.paligot.confily.backend.quiz.infrastructure.exposed.QuizPlayersTable
 import com.paligot.confily.models.inputs.QuizAnswerInput
@@ -16,6 +17,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 
 class QuizRepositoryExposedTest {
@@ -40,6 +42,22 @@ class QuizRepositoryExposedTest {
         assertTrue(playerId.isNotBlank())
         val count = transaction(database) { QuizPlayersTable.selectAll().count() }
         assertEquals(1, count)
+    }
+
+    @Test
+    fun `registerPlayer stores a hashed device id, not the raw value`() = runBlocking {
+        val eventId = QuizTestFixtures.createEvent(database)
+
+        repository.registerPlayer(
+            eventId.toString(),
+            QuizPlayerInput(username = "Alice", deviceId = "device-1")
+        )
+
+        val stored = transaction(database) {
+            QuizPlayersTable.selectAll().single()[QuizPlayersTable.deviceId]
+        }
+        assertNotEquals("device-1", stored)
+        assertEquals(DeviceIdHasher.hash("device-1"), stored)
     }
 
     @Test

--- a/backend/src/test/java/com/paligot/confily/backend/quiz/QuizRepositoryExposedTest.kt
+++ b/backend/src/test/java/com/paligot/confily/backend/quiz/QuizRepositoryExposedTest.kt
@@ -65,7 +65,9 @@ class QuizRepositoryExposedTest {
         val eventId = QuizTestFixtures.createEvent(database)
         val partnerId = QuizTestFixtures.createPartner(database, eventId, quizCode = "ABCD")
         QuizTestFixtures.createQuestion(
-            database, eventId, partnerId,
+            database,
+            eventId,
+            partnerId,
             question = "Capital of France?",
             options = listOf("Paris", "Lyon", "Nice"),
             correctIndex = 0,
@@ -92,10 +94,22 @@ class QuizRepositoryExposedTest {
         val eventId = QuizTestFixtures.createEvent(database)
         val partnerId = QuizTestFixtures.createPartner(database, eventId, quizCode = "ABCD")
         val q1 = QuizTestFixtures.createQuestion(
-            database, eventId, partnerId, "Q1", listOf("right", "wrong"), correctIndex = 0, order = 0
+            database,
+            eventId,
+            partnerId,
+            "Q1",
+            listOf("right", "wrong"),
+            correctIndex = 0,
+            order = 0
         )
         val q2 = QuizTestFixtures.createQuestion(
-            database, eventId, partnerId, "Q2", listOf("wrong", "right"), correctIndex = 1, order = 1
+            database,
+            eventId,
+            partnerId,
+            "Q2",
+            listOf("wrong", "right"),
+            correctIndex = 1,
+            order = 1
         )
         repository.registerPlayer(eventId.toString(), QuizPlayerInput("Alice", "device-1"))
 
@@ -125,7 +139,12 @@ class QuizRepositoryExposedTest {
         val eventId = QuizTestFixtures.createEvent(database)
         val partnerId = QuizTestFixtures.createPartner(database, eventId, quizCode = "ABCD")
         val q1 = QuizTestFixtures.createQuestion(
-            database, eventId, partnerId, "Q1", listOf("right", "wrong"), correctIndex = 0
+            database,
+            eventId,
+            partnerId,
+            "Q1",
+            listOf("right", "wrong"),
+            correctIndex = 0
         )
         runBlocking { repository.registerPlayer(eventId.toString(), QuizPlayerInput("Alice", "device-1")) }
         val answer = QuizTestFixtures.answerIds(database, q1)[0]
@@ -142,7 +161,12 @@ class QuizRepositoryExposedTest {
         val eventId = QuizTestFixtures.createEvent(database)
         val partnerId = QuizTestFixtures.createPartner(database, eventId, quizCode = "ABCD")
         val q1 = QuizTestFixtures.createQuestion(
-            database, eventId, partnerId, "Q1", listOf("right", "wrong"), correctIndex = 0
+            database,
+            eventId,
+            partnerId,
+            "Q1",
+            listOf("right", "wrong"),
+            correctIndex = 0
         )
         val answer = QuizTestFixtures.answerIds(database, q1)[0]
 
@@ -162,7 +186,12 @@ class QuizRepositoryExposedTest {
         val eventId = QuizTestFixtures.createEvent(database)
         val partnerId = QuizTestFixtures.createPartner(database, eventId, quizCode = "ABCD")
         val q1 = QuizTestFixtures.createQuestion(
-            database, eventId, partnerId, "Q1", listOf("right", "wrong"), correctIndex = 0
+            database,
+            eventId,
+            partnerId,
+            "Q1",
+            listOf("right", "wrong"),
+            correctIndex = 0
         )
         val correct = QuizTestFixtures.answerIds(database, q1)[0]
         val wrong = QuizTestFixtures.answerIds(database, q1)[1]
@@ -170,11 +199,13 @@ class QuizRepositoryExposedTest {
         repository.registerPlayer(eventId.toString(), QuizPlayerInput("Alice", "device-a"))
         repository.registerPlayer(eventId.toString(), QuizPlayerInput("Bob", "device-b"))
         repository.submit(
-            eventId.toString(), "ABCD",
+            eventId.toString(),
+            "ABCD",
             QuizSubmissionInput("device-a", listOf(QuizAnswerInput(q1.toString(), correct.toString())))
         )
         repository.submit(
-            eventId.toString(), "ABCD",
+            eventId.toString(),
+            "ABCD",
             QuizSubmissionInput("device-b", listOf(QuizAnswerInput(q1.toString(), wrong.toString())))
         )
 

--- a/backend/src/test/java/com/paligot/confily/backend/quiz/QuizRepositoryExposedTest.kt
+++ b/backend/src/test/java/com/paligot/confily/backend/quiz/QuizRepositoryExposedTest.kt
@@ -1,5 +1,6 @@
 package com.paligot.confily.backend.quiz
 
+import com.paligot.confily.backend.NotFoundException
 import com.paligot.confily.backend.internals.infrastructure.exposed.DatabaseFactory
 import com.paligot.confily.backend.quiz.application.QuizRepositoryExposed
 import com.paligot.confily.backend.quiz.infrastructure.exposed.QuizPlayersTable
@@ -11,6 +12,7 @@ import org.jetbrains.exposed.sql.transactions.transaction
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class QuizRepositoryExposedTest {
@@ -53,5 +55,32 @@ class QuizRepositoryExposedTest {
         assertEquals(first, second)
         val count = transaction(database) { QuizPlayersTable.selectAll().count() }
         assertEquals(1, count)
+    }
+
+    @Test
+    fun `questionsByCode returns ordered questions with options and no correctness leak`() = runBlocking {
+        val eventId = QuizTestFixtures.createEvent(database)
+        val partnerId = QuizTestFixtures.createPartner(database, eventId, quizCode = "ABCD")
+        QuizTestFixtures.createQuestion(
+            database, eventId, partnerId,
+            question = "Capital of France?",
+            options = listOf("Paris", "Lyon", "Nice"),
+            correctIndex = 0,
+            order = 0
+        )
+
+        val questions = repository.questionsByCode(eventId.toString(), "ABCD")
+
+        assertEquals(1, questions.size)
+        assertEquals("Capital of France?", questions[0].question)
+        assertEquals(listOf("Paris", "Lyon", "Nice"), questions[0].options.map { it.label })
+    }
+
+    @Test
+    fun `questionsByCode throws NotFound for an unknown code`() {
+        val eventId = QuizTestFixtures.createEvent(database)
+        assertFailsWith<NotFoundException> {
+            runBlocking { repository.questionsByCode(eventId.toString(), "ZZZZ") }
+        }
     }
 }

--- a/backend/src/test/java/com/paligot/confily/backend/quiz/QuizRepositoryExposedTest.kt
+++ b/backend/src/test/java/com/paligot/confily/backend/quiz/QuizRepositoryExposedTest.kt
@@ -156,4 +156,36 @@ class QuizRepositoryExposedTest {
             }
         }
     }
+
+    @Test
+    fun `leaderboard ranks by score desc then by earliest completion`() = runBlocking {
+        val eventId = QuizTestFixtures.createEvent(database)
+        val partnerId = QuizTestFixtures.createPartner(database, eventId, quizCode = "ABCD")
+        val q1 = QuizTestFixtures.createQuestion(
+            database, eventId, partnerId, "Q1", listOf("right", "wrong"), correctIndex = 0
+        )
+        val correct = QuizTestFixtures.answerIds(database, q1)[0]
+        val wrong = QuizTestFixtures.answerIds(database, q1)[1]
+
+        repository.registerPlayer(eventId.toString(), QuizPlayerInput("Alice", "device-a"))
+        repository.registerPlayer(eventId.toString(), QuizPlayerInput("Bob", "device-b"))
+        repository.submit(
+            eventId.toString(), "ABCD",
+            QuizSubmissionInput("device-a", listOf(QuizAnswerInput(q1.toString(), correct.toString())))
+        )
+        repository.submit(
+            eventId.toString(), "ABCD",
+            QuizSubmissionInput("device-b", listOf(QuizAnswerInput(q1.toString(), wrong.toString())))
+        )
+
+        val board = repository.leaderboard(eventId.toString())
+
+        assertEquals(2, board.size)
+        assertEquals("Alice", board[0].username)
+        assertEquals(1, board[0].score)
+        assertEquals(1, board[0].rank)
+        assertEquals("Bob", board[1].username)
+        assertEquals(0, board[1].score)
+        assertEquals(2, board[1].rank)
+    }
 }

--- a/backend/src/test/java/com/paligot/confily/backend/quiz/QuizTestFixtures.kt
+++ b/backend/src/test/java/com/paligot/confily/backend/quiz/QuizTestFixtures.kt
@@ -29,6 +29,7 @@ object QuizTestFixtures {
             }.id.value
         }
 
+    @Suppress("LongParameterList")
     fun createQuestion(
         database: Database,
         eventId: UUID,

--- a/backend/src/test/java/com/paligot/confily/backend/quiz/QuizTestFixtures.kt
+++ b/backend/src/test/java/com/paligot/confily/backend/quiz/QuizTestFixtures.kt
@@ -1,0 +1,65 @@
+package com.paligot.confily.backend.quiz
+
+import com.paligot.confily.backend.events.infrastructure.exposed.EventEntity
+import com.paligot.confily.backend.partners.infrastructure.exposed.PartnerEntity
+import com.paligot.confily.backend.quiz.infrastructure.exposed.QuizAnswerEntity
+import com.paligot.confily.backend.quiz.infrastructure.exposed.QuizQuestionEntity
+import kotlinx.datetime.LocalDate
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.transactions.transaction
+import java.util.UUID
+
+object QuizTestFixtures {
+    fun createEvent(database: Database, slug: String = "event-${UUID.randomUUID()}"): UUID =
+        transaction(database) {
+            EventEntity.new {
+                this.slug = slug
+                this.name = "Test Event"
+                this.startDate = LocalDate(2026, 6, 1)
+                this.endDate = LocalDate(2026, 6, 2)
+            }.id.value
+        }
+
+    fun createPartner(database: Database, eventId: UUID, quizCode: String? = null): UUID =
+        transaction(database) {
+            PartnerEntity.new {
+                this.event = EventEntity[eventId]
+                this.name = "Partner ${UUID.randomUUID()}"
+                this.quizCode = quizCode
+            }.id.value
+        }
+
+    fun createQuestion(
+        database: Database,
+        eventId: UUID,
+        partnerId: UUID,
+        question: String,
+        options: List<String>,
+        correctIndex: Int,
+        order: Int = 0
+    ): UUID = transaction(database) {
+        val questionEntity = QuizQuestionEntity.new {
+            this.event = EventEntity[eventId]
+            this.partner = PartnerEntity[partnerId]
+            this.question = question
+            this.displayOrder = order
+        }
+        options.forEachIndexed { index, label ->
+            QuizAnswerEntity.new {
+                this.question = questionEntity
+                this.answer = label
+                this.isCorrect = index == correctIndex
+                this.displayOrder = index
+            }
+        }
+        questionEntity.id.value
+    }
+
+    fun correctAnswerId(database: Database, questionId: UUID): UUID = transaction(database) {
+        QuizAnswerEntity.findByQuestion(questionId).first { it.isCorrect }.id.value
+    }
+
+    fun answerIds(database: Database, questionId: UUID): List<UUID> = transaction(database) {
+        QuizAnswerEntity.findByQuestion(questionId).map { it.id.value }
+    }
+}

--- a/backend/src/test/java/com/paligot/confily/backend/third/parties/partnersconnect/PartnersConnectQuizIngestionTest.kt
+++ b/backend/src/test/java/com/paligot/confily/backend/third/parties/partnersconnect/PartnersConnectQuizIngestionTest.kt
@@ -1,0 +1,146 @@
+package com.paligot.confily.backend.third.parties.partnersconnect
+
+import com.paligot.confily.backend.addresses.infrastructure.provider.GeocodeApi
+import com.paligot.confily.backend.internals.infrastructure.exposed.DatabaseFactory
+import com.paligot.confily.backend.partners.infrastructure.exposed.PartnerEntity
+import com.paligot.confily.backend.quiz.infrastructure.exposed.QuizAnswerEntity
+import com.paligot.confily.backend.quiz.infrastructure.exposed.QuizAnswersTable
+import com.paligot.confily.backend.quiz.infrastructure.exposed.QuizQuestionEntity
+import com.paligot.confily.backend.quiz.infrastructure.exposed.QuizQuestionsTable
+import com.paligot.confily.backend.third.parties.partnersconnect.application.PartnersConnectRepositoryExposed
+import com.paligot.confily.backend.third.parties.partnersconnect.infrastructure.provider.Company
+import com.paligot.confily.backend.third.parties.partnersconnect.infrastructure.provider.CompanyStatus
+import com.paligot.confily.backend.third.parties.partnersconnect.infrastructure.provider.EventSummary
+import com.paligot.confily.backend.third.parties.partnersconnect.infrastructure.provider.Media
+import com.paligot.confily.backend.third.parties.partnersconnect.infrastructure.provider.PartnersConnectWebhookPayload
+import com.paligot.confily.backend.third.parties.partnersconnect.infrastructure.provider.PartnershipDetail
+import com.paligot.confily.backend.third.parties.partnersconnect.infrastructure.provider.PartnershipPack
+import com.paligot.confily.backend.third.parties.partnersconnect.infrastructure.provider.PartnershipProcessStatus
+import com.paligot.confily.backend.third.parties.partnersconnect.infrastructure.provider.WebhookAnswer
+import com.paligot.confily.backend.third.parties.partnersconnect.infrastructure.provider.WebhookEventType
+import com.paligot.confily.backend.third.parties.partnersconnect.infrastructure.provider.WebhookQuestion
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.SortOrder
+import org.jetbrains.exposed.sql.transactions.transaction
+import java.util.UUID
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class PartnersConnectQuizIngestionTest {
+    private lateinit var database: Database
+    private lateinit var repository: PartnersConnectRepositoryExposed
+    private lateinit var eventId: UUID
+
+    @BeforeTest
+    fun setup() {
+        database = DatabaseFactory.createTestDatabase()
+        repository = PartnersConnectRepositoryExposed(database, mockk<GeocodeApi>())
+        eventId = com.paligot.confily.backend.quiz.QuizTestFixtures.createEvent(database)
+    }
+
+    private fun payload(questions: List<WebhookQuestion>) = PartnersConnectWebhookPayload(
+        eventType = WebhookEventType.CREATED,
+        partnership = PartnershipDetail(
+            id = "partnership-1",
+            language = "en",
+            validatedPack = PartnershipPack(id = "pack-1", name = "Gold"),
+            processStatus = PartnershipProcessStatus(billingStatus = "paid"),
+            createdAt = "2026-01-01T00:00:00"
+        ),
+        company = Company(
+            id = "company-1",
+            name = "ACME",
+            headOffice = null,
+            siret = null,
+            vat = null,
+            description = "desc",
+            siteUrl = "https://acme.test",
+            medias = Media(
+                original = "https://acme.test/logo.svg",
+                png1000 = "https://acme.test/1000.png",
+                png500 = "https://acme.test/500.png",
+                png250 = "https://acme.test/250.png"
+            ),
+            status = CompanyStatus.ACTIVE,
+            socials = emptyList()
+        ),
+        event = EventSummary(slug = "test-event", name = "Test Event"),
+        jobs = emptyList(),
+        activities = emptyList(),
+        speakers = emptyList(),
+        supportVideoUrl = null,
+        timestamp = "2026-01-01T00:00:00",
+        questions = questions
+    )
+
+    @Test
+    fun `webhook ingests questions, answers and assigns a 4-letter quiz code`() = runBlocking {
+        val partnerId = UUID.fromString(
+            repository.webhook(
+                eventId.toString(),
+                payload(
+                    listOf(
+                        WebhookQuestion(
+                            id = "q1",
+                            question = "Capital of France?",
+                            order = 0,
+                            answers = listOf(
+                                WebhookAnswer(id = "a1", answer = "Paris", isCorrect = true, order = 0),
+                                WebhookAnswer(id = "a2", answer = "Lyon", isCorrect = false, order = 1)
+                            )
+                        )
+                    )
+                )
+            )
+        )
+
+        transaction(database) {
+            val partner = PartnerEntity[partnerId]
+            assertNotNull(partner.quizCode)
+            assertEquals(4, partner.quizCode!!.length)
+
+            val questions = QuizQuestionEntity.findByPartner(partnerId)
+                .orderBy(QuizQuestionsTable.displayOrder to SortOrder.ASC)
+                .toList()
+            assertEquals(1, questions.size)
+            assertEquals("Capital of France?", questions[0].question)
+
+            val answers = QuizAnswerEntity.findByQuestion(questions[0].id.value)
+                .orderBy(QuizAnswersTable.displayOrder to SortOrder.ASC)
+                .toList()
+            assertEquals(listOf("Paris", "Lyon"), answers.map { it.answer })
+            assertTrue(answers[0].isCorrect)
+            assertTrue(!answers[1].isCorrect)
+        }
+    }
+
+    @Test
+    fun `webhook re-sync removes questions no longer present`() = runBlocking {
+        val firstPartnerId = UUID.fromString(
+            repository.webhook(
+                eventId.toString(),
+                payload(
+                    listOf(
+                        WebhookQuestion("q1", "Q1", 0, listOf(WebhookAnswer("a1", "A", true, 0))),
+                        WebhookQuestion("q2", "Q2", 1, listOf(WebhookAnswer("a2", "B", true, 0)))
+                    )
+                )
+            )
+        )
+        repository.webhook(
+            eventId.toString(),
+            payload(listOf(WebhookQuestion("q1", "Q1 updated", 0, listOf(WebhookAnswer("a1", "A", true, 0)))))
+        )
+
+        transaction(database) {
+            val questions = QuizQuestionEntity.findByPartner(firstPartnerId).toList()
+            assertEquals(1, questions.size)
+            assertEquals("Q1 updated", questions[0].question)
+        }
+    }
+}

--- a/backend/src/test/java/com/paligot/confily/backend/third/parties/partnersconnect/PartnersConnectQuizIngestionTest.kt
+++ b/backend/src/test/java/com/paligot/confily/backend/third/parties/partnersconnect/PartnersConnectQuizIngestionTest.kt
@@ -120,6 +120,60 @@ class PartnersConnectQuizIngestionTest {
     }
 
     @Test
+    fun `webhook re-sync updates answers in place and removes answers no longer present`() = runBlocking {
+        val partnerId = UUID.fromString(
+            repository.webhook(
+                eventId.toString(),
+                payload(
+                    listOf(
+                        WebhookQuestion(
+                            id = "q1",
+                            question = "Q1",
+                            order = 0,
+                            answers = listOf(
+                                WebhookAnswer("a1", "Paris", true, 0),
+                                WebhookAnswer("a2", "Lyon", false, 1)
+                            )
+                        )
+                    )
+                )
+            )
+        )
+        val originalAnswerIds = transaction(database) {
+            val question = QuizQuestionEntity.findByPartner(partnerId).toList().single()
+            QuizAnswerEntity.findByQuestion(question.id.value).associate { it.externalId to it.id.value }
+        }
+
+        repository.webhook(
+            eventId.toString(),
+            payload(
+                listOf(
+                    WebhookQuestion(
+                        id = "q1",
+                        question = "Q1",
+                        order = 0,
+                        answers = listOf(
+                            WebhookAnswer("a1", "Paris (updated)", true, 0),
+                            WebhookAnswer("a3", "Nice", false, 1)
+                        )
+                    )
+                )
+            )
+        )
+
+        transaction(database) {
+            val question = QuizQuestionEntity.findByPartner(partnerId).toList().single()
+            val answers = QuizAnswerEntity.findByQuestion(question.id.value)
+                .orderBy(QuizAnswersTable.displayOrder to SortOrder.ASC)
+                .toList()
+            assertEquals(listOf("a1", "a3"), answers.map { it.externalId })
+            assertEquals(listOf("Paris (updated)", "Nice"), answers.map { it.answer })
+            // a1 keeps its primary key, so any submission row referencing it survives the re-sync.
+            assertEquals(originalAnswerIds["a1"], answers.first { it.externalId == "a1" }.id.value)
+        }
+    }
+
+    @Test
     fun `webhook re-sync removes questions no longer present`() = runBlocking {
         val firstPartnerId = UUID.fromString(
             repository.webhook(

--- a/shared/models/src/commonMain/kotlin/com/paligot/confily/models/Quiz.kt
+++ b/shared/models/src/commonMain/kotlin/com/paligot/confily/models/Quiz.kt
@@ -1,0 +1,48 @@
+package com.paligot.confily.models
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class QuizAnswerOption(
+    val id: String,
+    val label: String,
+    val order: Int
+)
+
+@Serializable
+data class QuizQuestion(
+    val id: String,
+    val order: Int,
+    val question: String,
+    val options: List<QuizAnswerOption>
+)
+
+@Serializable
+data class QuizAnsweredQuestion(
+    @SerialName("question_id")
+    val questionId: String,
+    @SerialName("chosen_answer_id")
+    val chosenAnswerId: String?,
+    @SerialName("correct_answer_id")
+    val correctAnswerId: String,
+    @SerialName("is_correct")
+    val isCorrect: Boolean
+)
+
+@Serializable
+data class QuizSubmissionResult(
+    @SerialName("correct_count")
+    val correctCount: Int,
+    @SerialName("total_count")
+    val totalCount: Int,
+    @SerialName("per_question")
+    val perQuestion: List<QuizAnsweredQuestion>
+)
+
+@Serializable
+data class LeaderboardEntry(
+    val rank: Int,
+    val username: String,
+    val score: Int
+)

--- a/shared/models/src/commonMain/kotlin/com/paligot/confily/models/inputs/QuizInput.kt
+++ b/shared/models/src/commonMain/kotlin/com/paligot/confily/models/inputs/QuizInput.kt
@@ -1,0 +1,42 @@
+package com.paligot.confily.models.inputs
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class QuizPlayerInput(
+    val username: String,
+    @SerialName("device_id")
+    val deviceId: String
+) : Validator {
+    override fun validate(): List<String> {
+        val errors = mutableListOf<String>()
+        if (username.isBlank()) errors.add("Username cannot be blank")
+        if (deviceId.isBlank()) errors.add("Device id cannot be blank")
+        return errors
+    }
+}
+
+@Serializable
+data class QuizAnswerInput(
+    @SerialName("question_id")
+    val questionId: String,
+    @SerialName("answer_id")
+    val answerId: String
+) : Validator {
+    override fun validate(): List<String> = emptyList()
+}
+
+@Serializable
+data class QuizSubmissionInput(
+    @SerialName("device_id")
+    val deviceId: String,
+    val answers: List<QuizAnswerInput>
+) : Validator {
+    override fun validate(): List<String> {
+        val errors = mutableListOf<String>()
+        if (deviceId.isBlank()) errors.add("Device id cannot be blank")
+        if (answers.isEmpty()) errors.add("Answers cannot be empty")
+        return errors
+    }
+}


### PR DESCRIPTION
## Summary
- New `quiz` backend bounded context (Ktor + Exposed): a partner quiz/scavenger-hunt game with an event leaderboard.
- Questions & answers are ingested from the existing **partners-connect webhook** (delete-diff upsert by `externalId`); each partner with questions gets a unique 4-letter `quiz_code` (collision-checked, generated once).
- Players are identified by `(eventId, deviceId)` (device UUID is the anti-cheat anchor; username is a display label). Re-registering a device updates the username.
- Answers are **graded server-side**, with a per-`(player, partner)` submission lock (second submit → 409). The answer key (`isCorrect`) is stored server-side only and **never serialized to the app** — the public `QuizQuestion`/`QuizAnswerOption` models have no correctness field, so the leak is structurally impossible.
- Leaderboard ranks players by total correct answers, tie-broken by earliest completion.

Public endpoints under `/events/{eventId}`:
- `POST /quiz/players` — register/update a player → `{ id }`
- `GET /quiz/partners/{code}` — that partner's questions + options (no answer key); 404 on unknown code
- `POST /quiz/partners/{code}/submit` — grade + lock; 409 if already submitted
- `GET /quiz/leaderboard` — ranked players

Infra: 5 new tables registered in `DatabaseFactory`; a migration adds the `partners.quiz_code` column; routes wired into the public events block (not `/admin`).

## Test plan
- 12 new backend tests (H2 in-memory): code generation & alphabet; player upsert (no duplicate per device); question fetch hides the answer key; server-side grading; 409 on re-submit; leaderboard ordering; webhook ingestion + 4-letter code assignment + re-sync removal.
- `./gradlew :backend:test` → green (12/12).
- `./gradlew :backend:ktlintCheck :backend:detekt :shared:models:ktlintCheck :shared:models:detekt` → clean.

## Follow-ups (intentionally not in this PR)
- `FeatureKey.Quiz` event toggle + `hasQuiz` on `FeaturesActivated` — deferred to the app-integration phase (touches the shared model the apps consume).
- Validate exactly-one-correct answer at ingestion (grading currently assumes it; a malformed question would error at submit time).
- Android/iOS UI integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)