### PR TITLE
Fix ML Kit scan-ticket crash in release builds (R8 keep rule)

### DIFF
--- a/androidApp/proguard-rules.pro
+++ b/androidApp/proguard-rules.pro
@@ -20,3 +20,11 @@
 
 # See https://github.com/firebase/firebase-android-sdk/issues/2124
 -keep class com.google.android.gms.internal.** { *; }
+
+# ML Kit resolves its barcode scanner via an internal component registry
+# (CommonComponentRegistrar + MlKitContext). R8 full mode over-shrinks this
+# wiring, so BarcodeScanning.getClient() returns a component with a null field
+# and the scan-ticket screen crashes in release only. The barcode-scanning AAR's
+# consumer rules cover the gms.internal side (already kept above) but not the
+# com.google.mlkit.* package itself.
+-keep class com.google.mlkit.** { *; }


### PR DESCRIPTION
## Problem

Tapping **Scan ticket** crashes with a `NullPointerException` in **release builds only** — debug works fine because R8 doesn't run there.

```
java.lang.NullPointerException: Attempt to read from field 'hh.e hh.c.a'
on a null object reference in method 'void sn.a.b(int, c3.t, o2.q, oq.k)'
```

## Root cause

De-obfuscating against the release `mapping.txt`:

| Obfuscated | Real identity |
|---|---|
| `hh.c` / `hh.c.a` | `com.google.mlkit.vision.barcode.internal.zzg` / its `zza` field |
| `sn.a.b(int, c3.t, o2.q, oq.k)` | the `CameraPreview` `@Composable` (`Modifier`, `Function1`, `Composer`) |

`BarcodeScanning.getClient(options)` (called in `CameraPreview`'s `remember { … }`) returned a barcode pipeline component that ML Kit's `MlKitContext` failed to resolve, so reading its internal field NPE'd.

Under **R8 full mode (AGP 9.0.1)** the `com.google.mlkit.*` package — ML Kit's component-registration infra (`CommonComponentRegistrar`, `MlKitContext`, `BarcodeRegistrar`) — was being shrunk/obfuscated with **no keep rule** covering it. The `com.google.android.gms.internal.mlkit_vision_barcode_bundled.**` half was already protected by the existing Firebase `-keep class com.google.android.gms.internal.** { *; }` rule.

## Fix

One targeted rule in `androidApp/proguard-rules.pro`:

```proguard
-keep class com.google.mlkit.** { *; }
```

## Verification

- Release build (`:androidApp:assembleRelease`) succeeds.
- Regenerated mapping retains **all** `com.google.mlkit` classes — before: **54** stripped/obfuscated, after: **0**; `zzg` keeps its original name and members; `usage.txt` no longer removes any ML Kit internals.
- Also fixes the networking VCard **Scan contact** scanner, which uses the same ML Kit path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)