### PR TITLE
Fix schedule grid crash from duplicate session keys

### DIFF
--- a/features/schedules/schedules-panes/src/commonMain/kotlin/com/paligot/confily/schedules/panes/ScheduleGridContent.kt
+++ b/features/schedules/schedules-panes/src/commonMain/kotlin/com/paligot/confily/schedules/panes/ScheduleGridContent.kt
@@ -7,7 +7,7 @@ import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
@@ -74,33 +74,41 @@ fun ScheduleGridContent(
                     horizontalArrangement = Arrangement.spacedBy(mediumSpacing)
                 ) {
                     agenda.sessions.entries.forEach { slot ->
-                        item(span = { GridItemSpan(count) }) {
+                        item(
+                            span = { GridItemSpan(count) },
+                            key = "header-${slot.key}"
+                        ) {
                             Time(
                                 time = slot.key,
                                 modifier = Modifier.placeholder(visible = isLoading)
                             )
                         }
-                        items(slot.value.toList(), key = { it.id }) {
-                            when (it) {
+                        // Key by slot + position so the grid can never receive a
+                        // duplicate key, even if two sessions share an id.
+                        itemsIndexed(
+                            items = slot.value,
+                            key = { index, item -> "${slot.key}-$index-${item.id}" }
+                        ) { _, item ->
+                            when (item) {
                                 is EventSessionItemUi -> {
                                     if (isSmallSize) {
                                         SmallPauseItem(
-                                            title = it.title,
-                                            room = it.room,
-                                            time = it.time,
-                                            timeImageVector = it.timeInMinutes.findTimeImageVector(),
+                                            title = item.title,
+                                            room = item.room,
+                                            time = item.time,
+                                            timeImageVector = item.timeInMinutes.findTimeImageVector(),
                                             modifier = Modifier.placeholder(visible = isLoading)
                                         )
                                     } else {
                                         MediumPauseItem(
-                                            title = it.title,
-                                            room = it.room,
-                                            time = it.time,
-                                            timeImageVector = it.timeInMinutes.findTimeImageVector(),
+                                            title = item.title,
+                                            room = item.room,
+                                            time = item.time,
+                                            timeImageVector = item.timeInMinutes.findTimeImageVector(),
                                             modifier = Modifier.placeholder(visible = isLoading),
-                                            onClick = if (it.isClickable) {
+                                            onClick = if (item.isClickable) {
                                                 {
-                                                    onEventSessionClicked(it.id)
+                                                    onEventSessionClicked(item.id)
                                                 }
                                             } else {
                                                 null
@@ -112,14 +120,14 @@ fun ScheduleGridContent(
                                 is TalkItemUi -> {
                                     if (isSmallSize) {
                                         SmallScheduleItem(
-                                            talk = it,
+                                            talk = item,
                                             modifier = Modifier.placeholder(visible = isLoading),
                                             onFavoriteClicked = onFavoriteClicked,
                                             onTalkClicked = onTalkClicked
                                         )
                                     } else {
                                         MediumScheduleItem(
-                                            talk = it,
+                                            talk = item,
                                             modifier = Modifier.placeholder(visible = isLoading),
                                             onFavoriteClicked = onFavoriteClicked,
                                             onTalkClicked = onTalkClicked

--- a/shared/core/src/mobileMain/kotlin/com/paligot/confily/core/schedules/SessionDaoSQLDelight.kt
+++ b/shared/core/src/mobileMain/kotlin/com/paligot/confily/core/schedules/SessionDaoSQLDelight.kt
@@ -90,6 +90,10 @@ class SessionDaoSQLDelight(
                 .executeAsList()
             sessions
                 .sessionFiltered(categories, formats, hasFavFilter)
+                // selectSessions joins the many-to-many SessionCategory/SessionFormat
+                // tables, so a talk with several categories or formats appears once
+                // per combination. Collapse back to one item per session id.
+                .distinctBy { it.id }
                 .map { session ->
                     val speakersByTalk = speakers
                         .filter { it.talk_id == session.id }
@@ -140,6 +144,7 @@ class SessionDaoSQLDelight(
             .flatMapMerge { sessions ->
                 val nextSessions = sessions
                     .filter { dateTime < LocalDateTime.parse(it.start_time) }
+                    .distinctBy { it.id }
                 val sessionIds = nextSessions.mapNotNull { it.id }
                 db.sessionQueries
                     .selectSpeakersByTalkIds(eventId, sessionIds)


### PR DESCRIPTION
## Problem

Scrolling the schedule/agenda screen could crash for some events:

```
java.lang.IllegalArgumentException
  at androidx.compose.ui.layout.LayoutNodeSubcompositionsState.subcompose
  at androidx.compose.foundation.lazy.grid.LazyGridMeasureKt.measureLazyGrid
  at androidx.compose.foundation.lazy.grid.LazyGridState.onScroll$foundation
```

It was reported as "impossible to reproduce."

## Root cause

A SQL join fan-out surfacing as duplicate Compose keys:

1. `Session.sq` `selectSessions` inner-joins the **many-to-many** `SessionCategory` and `SessionFormat` tables with **no `GROUP BY`/`DISTINCT`** → a talk with N categories × M formats returns N×M identical rows (same `id`, same `start_time`).
2. `SessionDaoSQLDelight.fetchSessionsFiltered` maps those rows **1:1** to `SessionItem` (no dedup).
3. `Sessions.mapToListUi` groups by `startTime`, producing **multiple `TalkItemUi` with the same `id` in one time slot**.
4. `ScheduleGridContent` does `items(key = { it.id })` → **duplicate `LazyVerticalGrid` keys** → `subcompose` throws.

It only fires while **scrolling** (both colliding items composed in the same pass) and only for events that assign **multiple categories/formats** — hence unreproducible on single-category data and the sample `AgendaUi.fake`.

## Fix (two layers)

| File | Change |
|---|---|
| `SessionDaoSQLDelight.kt` | `.distinctBy { it.id }` in `fetchSessionsFiltered` + `fetchNextSessions` — collapses the fan-out at the source (also fixes a latent double-render) |
| `ScheduleGridContent.kt` | `items(key = { it.id })` → `itemsIndexed(key = { i, item -> "${slot.key}-$i-${item.id}" })` + keyed header — grid keys are now unique **by construction**, so a future data regression can't crash the UI |

The grid guard is in `commonMain`, so it protects the web/desktop targets too. The wasmJs data path reads a single `categoryId`/`formatId` per talk (no fan-out) and needed no data change.

## Verification

- `ktlintCheck`, `detekt`, `lintDebug` all green.
- No automated regression test added: there's no existing in-memory SQLDelight / Compose test harness for these layers, and the fix is a one-line dedup plus a key that is unique by construction. Happy to add a DAO test harness if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)