### PR TITLE
Add open_feedback_enabled flag with Android browser fallback

### DIFF
--- a/backend/src/main/java/com/paligot/confily/backend/events/application/EventAdminRepositoryExposed.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/events/application/EventAdminRepositoryExposed.kt
@@ -141,6 +141,18 @@ class EventAdminRepositoryExposed(
                 enabled = features.hasNetworking
             }
         }
+        val existingOpenFeedback =
+            EventFeatureEntity.findByFeatureKey(event.id.value, FeatureKey.OpenFeedback)
+        if (existingOpenFeedback != null) {
+            existingOpenFeedback.enabled = features.openFeedbackEnabled
+            existingOpenFeedback.updatedAt = Clock.System.now()
+        } else {
+            EventFeatureEntity.new {
+                this.event = event
+                featureKey = FeatureKey.OpenFeedback
+                enabled = features.openFeedbackEnabled
+            }
+        }
         eventId
     }
 }

--- a/backend/src/main/java/com/paligot/confily/backend/events/application/EventRepositoryExposed.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/events/application/EventRepositoryExposed.kt
@@ -169,7 +169,8 @@ class EventRepositoryExposed(
                 partners.others.isNotEmpty(),
             hasMenus = menus.isNotEmpty(),
             hasQAndA = qanda.isNotEmpty(),
-            hasBilletWebTicket = integration != null
+            hasBilletWebTicket = integration != null,
+            openFeedbackEnabled = features1[FeatureKey.OpenFeedback] ?: true
         )
         val socials = EventSocialsTable.findByEventId(eventUuid)
         Event(
@@ -234,7 +235,8 @@ class EventRepositoryExposed(
             hasPartnerList = partners.empty().not(),
             hasMenus = menus.isNotEmpty(),
             hasQAndA = qanda.isNotEmpty(),
-            hasBilletWebTicket = integration != null
+            hasBilletWebTicket = integration != null,
+            openFeedbackEnabled = features1[FeatureKey.OpenFeedback] ?: true
         )
         val socials = EventSocialsTable.findByEventId(eventUuid)
         EventV2(
@@ -290,7 +292,8 @@ class EventRepositoryExposed(
             hasPartnerList = partners.empty().not(),
             hasMenus = menus.isNotEmpty(),
             hasQAndA = qanda.empty().not(),
-            hasBilletWebTicket = integration != null
+            hasBilletWebTicket = integration != null,
+            openFeedbackEnabled = features1[FeatureKey.OpenFeedback] ?: true
         )
         val socials = EventSocialsTable.findByEventId(eventUuid)
         EventV3(
@@ -348,7 +351,8 @@ class EventRepositoryExposed(
             hasPartnerList = partners.empty().not(),
             hasMenus = menus.isNotEmpty(),
             hasQAndA = qanda.empty().not(),
-            hasBilletWebTicket = integration != null
+            hasBilletWebTicket = integration != null,
+            openFeedbackEnabled = features1[FeatureKey.OpenFeedback] ?: true
         )
 
         EventV4(
@@ -381,6 +385,9 @@ class EventRepositoryExposed(
     override suspend fun getV5(eventId: String): EventV5 = transaction(db = database) {
         val eventUuid = UUID.fromString(eventId)
         val event = EventEntity[eventUuid]
+        val features1 = EventFeatureEntity
+            .findByEvent(eventUuid)
+            .associate { it.featureKey to it.enabled }
         val socials = EventSocialsTable.findByEventId(eventUuid)
         val menus = LunchMenuEntity.findByEvent(eventUuid)
             .map { it.toModel() }
@@ -437,7 +444,8 @@ class EventRepositoryExposed(
                 hasPartnerList = true,
                 hasMenus = menus.isNotEmpty(),
                 hasQAndA = true,
-                hasBilletWebTicket = true
+                hasBilletWebTicket = true,
+                openFeedbackEnabled = features1[FeatureKey.OpenFeedback] ?: true
             ),
             team = groups.associate { group ->
                 val members = TeamEntity

--- a/backend/src/main/java/com/paligot/confily/backend/events/infrastructure/exposed/EventFeaturesTable.kt
+++ b/backend/src/main/java/com/paligot/confily/backend/events/infrastructure/exposed/EventFeaturesTable.kt
@@ -19,5 +19,6 @@ object EventFeaturesTable : UUIDTable("event_features") {
 }
 
 enum class FeatureKey(val key: String) {
-    Networking("has_networking")
+    Networking("has_networking"),
+    OpenFeedback("open_feedback_enabled")
 }

--- a/core/core-models-factory/src/commonMain/kotlin/com/paligot/confily/core/models/factory/Event.ext.kt
+++ b/core/core-models-factory/src/commonMain/kotlin/com/paligot/confily/core/models/factory/Event.ext.kt
@@ -30,6 +30,7 @@ class EventBuilder {
     private var menus: List<EventLunchMenu> = emptyList()
     private var coc: String = ""
     private var openfeedbackProjectId: String? = null
+    private var openFeedbackEnabled: Boolean = true
     private var features: FeaturesActivated = FeaturesActivated(
         hasNetworking = false,
         hasSpeakerList = false,
@@ -53,6 +54,8 @@ class EventBuilder {
     fun coc(coc: String) = apply { this.coc = coc }
     fun openfeedbackProjectId(openfeedbackProjectId: String?) =
         apply { this.openfeedbackProjectId = openfeedbackProjectId }
+
+    fun openFeedbackEnabled(enabled: Boolean) = apply { this.openFeedbackEnabled = enabled }
 
     fun features(features: FeaturesActivated) = apply { this.features = features }
     fun contactPhone(contactPhone: String?) = apply { this.contactPhone = contactPhone }
@@ -78,7 +81,7 @@ class EventBuilder {
             content = emptyMap(),
             link = faqLink
         ),
-        features = features,
+        features = features.copy(openFeedbackEnabled = openFeedbackEnabled),
         contact = EventContact(
             phone = contactPhone,
             email = contactEmail,

--- a/core/core-models-factory/src/commonMain/kotlin/com/paligot/confily/core/models/factory/Session.ext.kt
+++ b/core/core-models-factory/src/commonMain/kotlin/com/paligot/confily/core/models/factory/Session.ext.kt
@@ -13,6 +13,7 @@ class TalkBuilder {
     private var formatId: String = ""
     private var language: String = ""
     private var speakers: List<String> = emptyList()
+    private var openFeedback: String? = null
 
     fun id(id: String) = apply { this.id = id }
     fun title(title: String) = apply { this.title = title }
@@ -22,6 +23,7 @@ class TalkBuilder {
     fun formatId(formatId: String) = apply { this.formatId = formatId }
     fun language(language: String) = apply { this.language = language }
     fun speakers(speakers: List<String>) = apply { this.speakers = speakers }
+    fun openFeedback(openFeedback: String?) = apply { this.openFeedback = openFeedback }
 
     fun build(): Session.Talk = Session.Talk(
         id = id,
@@ -35,6 +37,6 @@ class TalkBuilder {
         speakers = speakers,
         linkSlides = null,
         linkReplay = null,
-        openFeedback = null
+        openFeedback = openFeedback
     )
 }

--- a/features/main/main/src/commonMain/kotlin/com/paligot/confily/main/MainNavigation.kt
+++ b/features/main/main/src/commonMain/kotlin/com/paligot/confily/main/MainNavigation.kt
@@ -108,7 +108,8 @@ fun MainNavigation(
                     exitTransition = exitSlideInHorizontal(),
                     popExitTransition = popExistSlideInHorizontal(),
                     onShareClicked = onShareClicked,
-                    onItineraryClicked = onItineraryClicked
+                    onItineraryClicked = onItineraryClicked,
+                    launchUrl = launchUrl
                 )
                 speakerGraph(
                     isLandscape = isPortrait.not(),

--- a/features/schedules/schedules-panes-models/src/commonMain/kotlin/com/paligot/confily/schedules/panes/models/SessionUi.kt
+++ b/features/schedules/schedules-panes-models/src/commonMain/kotlin/com/paligot/confily/schedules/panes/models/SessionUi.kt
@@ -11,6 +11,7 @@ data class SessionUi(
     val speakers: ImmutableList<SpeakerItemUi>,
     val speakersSharing: String,
     val canGiveFeedback: Boolean,
+    val openFeedbackEnabled: Boolean,
     val openFeedbackProjectId: String?,
     val openFeedbackSessionId: String?,
     val openFeedbackUrl: String?
@@ -22,6 +23,7 @@ data class SessionUi(
             speakers = persistentListOf(SpeakerItemUi.fake, SpeakerItemUi.fake),
             speakersSharing = "",
             canGiveFeedback = false,
+            openFeedbackEnabled = true,
             openFeedbackProjectId = null,
             openFeedbackSessionId = "e1Wt4hveV3UiEd5yxZ9k",
             openFeedbackUrl = "https://openfeedback.io/eimghD4rG79eQuZRu2oT/2022-06-10/e1Wt4hveV3UiEd5yxZ9k"

--- a/features/schedules/schedules-panes/src/commonMain/kotlin/com/paligot/confily/schedules/panes/FeedbackContent.kt
+++ b/features/schedules/schedules-panes/src/commonMain/kotlin/com/paligot/confily/schedules/panes/FeedbackContent.kt
@@ -18,9 +18,12 @@ import org.jetbrains.compose.resources.stringResource
 
 @Composable
 fun FeedbackContent(
+    openFeedbackEnabled: Boolean,
     openFeedbackProjectId: String?,
     openFeedbackSessionId: String?,
+    openFeedbackUrl: String?,
     canGiveFeedback: Boolean,
+    launchUrl: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     LazyColumn(
@@ -31,9 +34,12 @@ fun FeedbackContent(
         item {
             if (openFeedbackProjectId != null && openFeedbackSessionId != null) {
                 OpenFeedbackSection(
+                    openFeedbackEnabled = openFeedbackEnabled,
                     openFeedbackProjectId = openFeedbackProjectId,
                     openFeedbackSessionId = openFeedbackSessionId,
-                    canGiveFeedback = canGiveFeedback
+                    openFeedbackUrl = openFeedbackUrl.orEmpty(),
+                    canGiveFeedback = canGiveFeedback,
+                    launchUrl = launchUrl
                 )
             } else {
                 Text(

--- a/features/schedules/schedules-panes/src/commonMain/kotlin/com/paligot/confily/schedules/panes/ScheduleDetailContent.kt
+++ b/features/schedules/schedules-panes/src/commonMain/kotlin/com/paligot/confily/schedules/panes/ScheduleDetailContent.kt
@@ -26,6 +26,7 @@ import com.paligot.confily.style.theme.toDp
 fun ScheduleDetailContent(
     uiModel: SessionUi,
     onSpeakerClicked: (id: String) -> Unit,
+    launchUrl: (String) -> Unit,
     modifier: Modifier = Modifier,
     state: LazyListState = rememberLazyListState(),
     contentPadding: PaddingValues = PaddingValues(SpacingTokens.None.toDp())
@@ -52,9 +53,12 @@ fun ScheduleDetailContent(
             item {
                 if (!LocalInspectionMode.current) {
                     OpenFeedbackSection(
+                        openFeedbackEnabled = uiModel.openFeedbackEnabled,
                         openFeedbackProjectId = uiModel.openFeedbackProjectId!!,
                         openFeedbackSessionId = uiModel.openFeedbackSessionId!!,
-                        canGiveFeedback = uiModel.canGiveFeedback
+                        openFeedbackUrl = uiModel.openFeedbackUrl.orEmpty(),
+                        canGiveFeedback = uiModel.canGiveFeedback,
+                        launchUrl = launchUrl
                     )
                 }
             }

--- a/features/schedules/schedules-panes/src/commonMain/kotlin/com/paligot/confily/schedules/panes/ScheduleDetailPane.kt
+++ b/features/schedules/schedules-panes/src/commonMain/kotlin/com/paligot/confily/schedules/panes/ScheduleDetailPane.kt
@@ -31,6 +31,7 @@ fun ScheduleDetailPane(
     onBackClicked: () -> Unit,
     onSpeakerClicked: (id: String) -> Unit,
     onShareClicked: (text: String) -> Unit,
+    launchUrl: (String) -> Unit,
     modifier: Modifier = Modifier,
     isLandscape: Boolean = false
 ) {
@@ -73,13 +74,17 @@ fun ScheduleDetailPane(
                     ScheduleDetailContent(
                         uiModel = session,
                         onSpeakerClicked = onSpeakerClicked,
+                        launchUrl = launchUrl,
                         modifier = Modifier.weight(1f),
                         state = state
                     )
                     FeedbackContent(
+                        openFeedbackEnabled = session.openFeedbackEnabled,
                         openFeedbackProjectId = session.openFeedbackProjectId,
                         openFeedbackSessionId = session.openFeedbackSessionId,
+                        openFeedbackUrl = session.openFeedbackUrl,
                         canGiveFeedback = session.canGiveFeedback,
+                        launchUrl = launchUrl,
                         modifier = Modifier.weight(1f)
                     )
                 }
@@ -87,6 +92,7 @@ fun ScheduleDetailPane(
                 ScheduleDetailContent(
                     uiModel = session,
                     onSpeakerClicked = onSpeakerClicked,
+                    launchUrl = launchUrl,
                     state = state,
                     contentPadding = it
                 )
@@ -103,7 +109,8 @@ private fun ScheduleDetailContentPreview() {
         Surface {
             ScheduleDetailContent(
                 uiModel = SessionUi.fake,
-                onSpeakerClicked = {}
+                onSpeakerClicked = {},
+                launchUrl = {}
             )
         }
     }

--- a/features/schedules/schedules-presentation/src/commonMain/kotlin/com/paligot/confily/schedules/presentation/NavGraph.kt
+++ b/features/schedules/schedules-presentation/src/commonMain/kotlin/com/paligot/confily/schedules/presentation/NavGraph.kt
@@ -30,7 +30,8 @@ fun NavGraphBuilder.scheduleGraph(
     exitTransition: ExitTransition,
     popExitTransition: ExitTransition,
     onShareClicked: (text: String) -> Unit,
-    onItineraryClicked: (lat: Double, lng: Double) -> Unit
+    onItineraryClicked: (lat: Double, lng: Double) -> Unit,
+    launchUrl: (String) -> Unit
 ) {
     composable<ScheduleList>(
         enterTransition = { fadeIn() },
@@ -69,6 +70,7 @@ fun NavGraphBuilder.scheduleGraph(
             onBackClicked = { scope.launch { navController.popBackStack() } },
             onSpeakerClicked = { scope.launch { navController.navigate(Speaker(id = it)) } },
             onShareClicked = onShareClicked,
+            launchUrl = launchUrl,
             isLandscape = isPortrait.not()
         )
     }

--- a/features/schedules/schedules-presentation/src/commonMain/kotlin/com/paligot/confily/schedules/presentation/ScheduleDetailOrientableVM.kt
+++ b/features/schedules/schedules-presentation/src/commonMain/kotlin/com/paligot/confily/schedules/presentation/ScheduleDetailOrientableVM.kt
@@ -22,6 +22,7 @@ fun ScheduleDetailOrientableVM(
     onBackClicked: () -> Unit,
     onSpeakerClicked: (id: String) -> Unit,
     onShareClicked: (text: String) -> Unit,
+    launchUrl: (String) -> Unit,
     modifier: Modifier = Modifier,
     isLandscape: Boolean = false,
     viewModel: ScheduleDetailViewModel = koinViewModel(parameters = { parametersOf(scheduleId) })
@@ -37,6 +38,7 @@ fun ScheduleDetailOrientableVM(
                     onBackClicked = onBackClicked,
                     onSpeakerClicked = onSpeakerClicked,
                     onShareClicked = onShareClicked,
+                    launchUrl = launchUrl,
                     modifier = modifier,
                     isLandscape = isLandscape
                 )

--- a/features/schedules/schedules-presentation/src/commonMain/kotlin/com/paligot/confily/schedules/presentation/ScheduleDetailViewModel.kt
+++ b/features/schedules/schedules-presentation/src/commonMain/kotlin/com/paligot/confily/schedules/presentation/ScheduleDetailViewModel.kt
@@ -9,7 +9,7 @@ import com.paligot.confily.schedules.panes.models.SessionUi
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 
 sealed class ScheduleUiState {
@@ -23,8 +23,14 @@ class ScheduleDetailViewModel(
     repository: SessionRepository,
     strings: Strings
 ) : ViewModel() {
-    val uiState: StateFlow<ScheduleUiState> = repository.session(scheduleId)
-        .map { ScheduleUiState.Success(it.mapToSessionUi(strings)) as ScheduleUiState }
+    val uiState: StateFlow<ScheduleUiState> = combine(
+        repository.session(scheduleId),
+        repository.featureFlags()
+    ) { session, flags ->
+        ScheduleUiState.Success(
+            session.mapToSessionUi(strings, flags.openFeedbackEnabled)
+        ) as ScheduleUiState
+    }
         .catch { emit(ScheduleUiState.Failure(it)) }
         .stateIn(
             scope = viewModelScope,

--- a/features/schedules/schedules-sample/src/commonMain/kotlin/com/paligot/confily/schedules/sample/App.kt
+++ b/features/schedules/schedules-sample/src/commonMain/kotlin/com/paligot/confily/schedules/sample/App.kt
@@ -14,7 +14,8 @@ import com.paligot.confily.style.theme.ConfilyTheme
 @Composable
 fun App(
     isPortrait: Boolean,
-    adaptiveInfo: WindowSizeClass = adaptiveInfo()
+    adaptiveInfo: WindowSizeClass = adaptiveInfo(),
+    launchUrl: (String) -> Unit = {}
 ) {
     val navController = rememberNavController()
     ConfilyTheme {
@@ -33,7 +34,8 @@ fun App(
                     exitTransition = ExitTransition.None,
                     popExitTransition = ExitTransition.None,
                     onShareClicked = {},
-                    onItineraryClicked = { _, _ -> }
+                    onItineraryClicked = { _, _ -> },
+                    launchUrl = launchUrl
                 )
             }
         )

--- a/features/schedules/schedules-sample/src/desktopTest/kotlin/com/paligot/confily/schedules/sample/OpenFeedbackFallbackTest.kt
+++ b/features/schedules/schedules-sample/src/desktopTest/kotlin/com/paligot/confily/schedules/sample/OpenFeedbackFallbackTest.kt
@@ -1,0 +1,66 @@
+package com.paligot.confily.schedules.sample
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import com.paligot.confily.BuildKonfig
+import com.paligot.confily.core.events.EventDao
+import com.paligot.confily.core.kvalue.ConferenceSettings
+import com.paligot.confily.core.schedules.SessionDao
+import com.paligot.confily.core.test.FakeLifecycleOwner
+import com.paligot.confily.core.test.instrumentedModule
+import com.paligot.confily.core.test.patterns.navigation.RobotNavigator
+import com.paligot.confily.core.test.patterns.navigation.robotHost
+import com.paligot.confily.schedules.di.scheduleModule
+import com.paligot.confily.schedules.sample.fakes.AgendaFake.agenda
+import com.paligot.confily.schedules.sample.fakes.EventFake.event
+import com.paligot.confily.schedules.test.robot.schedules
+import com.paligot.confily.schedules.test.scheduleRobotGraph
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.koin.compose.KoinApplication
+import org.koin.compose.koinInject
+import java.util.Locale
+
+class OpenFeedbackFallbackTest {
+    @get:Rule
+    val rule = createComposeRule()
+
+    @Test
+    fun shouldShowGiveFeedbackButtonWhenOpenFeedbackDisabled() {
+        Locale.setDefault(Locale("en", "US"))
+        var launchedUrl: String? = null
+        rule.setContent {
+            KoinApplication(application = {
+                modules(platformModule, scheduleModule, instrumentedModule)
+            }) {
+                val settings = koinInject<ConferenceSettings>()
+                val eventDao = koinInject<EventDao>()
+                val sessionDao = koinInject<SessionDao>()
+                LaunchedEffect(Unit) {
+                    settings.insertEventId(BuildKonfig.DEFAULT_EVENT)
+                    eventDao.insertEvent(event)
+                    sessionDao.insertAgenda(BuildKonfig.DEFAULT_EVENT, agenda)
+                }
+                val lifecycleOwner = remember { FakeLifecycleOwner() }
+                CompositionLocalProvider(LocalLifecycleOwner provides lifecycleOwner) {
+                    App(isPortrait = true, launchUrl = { launchedUrl = it })
+                }
+            }
+        }
+        val navigator = RobotNavigator()
+        robotHost(navigator) {
+            scheduleRobotGraph(navigator, rule)
+        }
+        schedules(navigator) {
+        } goToSecheduleDetail {
+            assertGiveFeedbackButtonIsDisplayed()
+            clickGiveFeedbackButton()
+        } backToScheduleGrid {
+        }
+        assertEquals("https://openfeedback.io/project-id/session-id", launchedUrl)
+    }
+}

--- a/features/schedules/schedules-sample/src/desktopTest/kotlin/com/paligot/confily/schedules/sample/fakes/AgendaFake.kt
+++ b/features/schedules/schedules-sample/src/desktopTest/kotlin/com/paligot/confily/schedules/sample/fakes/AgendaFake.kt
@@ -11,7 +11,7 @@ import kotlinx.datetime.Clock
 import kotlin.time.Duration
 
 object AgendaFake {
-    private val startInstant = Clock.System.now().plus(Duration.parse("1h"))
+    private val startInstant = Clock.System.now().minus(Duration.parse("2h"))
 
     val schedule = ScheduleItemV4.builder()
         .id("session-id")
@@ -32,6 +32,7 @@ object AgendaFake {
         .formatId(format.id)
         .language("English")
         .speakers(listOf(speaker.id))
+        .openFeedback("https://openfeedback.io/project-id/session-id")
         .build()
     val agenda = AgendaV4(
         schedules = listOf(schedule),

--- a/features/schedules/schedules-sample/src/desktopTest/kotlin/com/paligot/confily/schedules/sample/fakes/EventFake.kt
+++ b/features/schedules/schedules-sample/src/desktopTest/kotlin/com/paligot/confily/schedules/sample/fakes/EventFake.kt
@@ -9,7 +9,9 @@ import kotlin.time.Duration
 object EventFake {
     val event = EventV5.builder()
         .id(BuildKonfig.DEFAULT_EVENT)
-        .startDate(Clock.System.now())
+        .startDate(Clock.System.now().minus(Duration.parse("2h")))
         .endDate(Clock.System.now().plus(Duration.parse("1d")))
+        .openfeedbackProjectId("project-id")
+        .openFeedbackEnabled(false)
         .build()
 }

--- a/features/schedules/schedules-semantics/src/commonMain/kotlin/com/paligot/confily/schedules/semantics/SchedulesSemantics.kt
+++ b/features/schedules/schedules-semantics/src/commonMain/kotlin/com/paligot/confily/schedules/semantics/SchedulesSemantics.kt
@@ -2,4 +2,5 @@ package com.paligot.confily.schedules.semantics
 
 object SchedulesSemantics {
     val list = "schedules:grid"
+    val giveFeedbackButton = "schedules:give-feedback-button"
 }

--- a/features/schedules/schedules-test-scopes/src/commonMain/kotlin/com/paligot/confily/schedules/test/scopes/ScheduleDetailsRobotScope.kt
+++ b/features/schedules/schedules-test-scopes/src/commonMain/kotlin/com/paligot/confily/schedules/test/scopes/ScheduleDetailsRobotScope.kt
@@ -10,5 +10,9 @@ interface ScheduleDetailsRobotScope {
         category: String
     )
 
+    fun assertGiveFeedbackButtonIsDisplayed()
+
+    fun clickGiveFeedbackButton()
+
     infix fun backToScheduleGrid(block: ScheduleGridRobotScope.() -> Unit): ScheduleGridRobotScope
 }

--- a/features/schedules/schedules-test/build.gradle.kts
+++ b/features/schedules/schedules-test/build.gradle.kts
@@ -7,6 +7,7 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             api(projects.features.schedules.schedulesTestScopes)
+            implementation(projects.features.schedules.schedulesSemantics)
         }
     }
 }

--- a/features/schedules/schedules-test/src/commonMain/kotlin/com/paligot/confily/schedules/test/pom/ScheduleDetailsPage.kt
+++ b/features/schedules/schedules-test/src/commonMain/kotlin/com/paligot/confily/schedules/test/pom/ScheduleDetailsPage.kt
@@ -6,8 +6,10 @@ import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import com.paligot.confily.core.test.patterns.withRole
+import com.paligot.confily.schedules.semantics.SchedulesSemantics
 
 class ScheduleDetailsPage(private val composeTestRule: ComposeTestRule) {
     private fun findMetadata(title: String, room: String, time: Int, category: String) =
@@ -25,6 +27,9 @@ class ScheduleDetailsPage(private val composeTestRule: ComposeTestRule) {
         withRole(Role.Button) and hasContentDescription("Back")
     )
 
+    private val giveFeedbackButton =
+        composeTestRule.onNodeWithTag(SchedulesSemantics.giveFeedbackButton)
+
     fun assertMetadata(title: String, room: String, time: Int, category: String) {
         findMetadata(title, room, time, category).assertIsDisplayed()
     }
@@ -35,6 +40,14 @@ class ScheduleDetailsPage(private val composeTestRule: ComposeTestRule) {
 
     fun assertSpeakers(speakers: List<String>) {
         speakers.forEach { findSpeaker(it).assertIsDisplayed() }
+    }
+
+    fun assertGiveFeedbackButton() {
+        giveFeedbackButton.assertIsDisplayed()
+    }
+
+    fun clickGiveFeedbackButton() {
+        giveFeedbackButton.assertIsDisplayed().performClick()
     }
 
     fun back() {

--- a/features/schedules/schedules-test/src/commonMain/kotlin/com/paligot/confily/schedules/test/robot/ScheduleDetailsRobot.kt
+++ b/features/schedules/schedules-test/src/commonMain/kotlin/com/paligot/confily/schedules/test/robot/ScheduleDetailsRobot.kt
@@ -28,6 +28,14 @@ class ScheduleDetailsRobot(
         }
     }
 
+    override fun assertGiveFeedbackButtonIsDisplayed() {
+        scheduleDetailsPage.assertGiveFeedbackButton()
+    }
+
+    override fun clickGiveFeedbackButton() {
+        scheduleDetailsPage.clickGiveFeedbackButton()
+    }
+
     override fun backToScheduleGrid(block: ScheduleGridRobotScope.() -> Unit): ScheduleGridRobotScope {
         scheduleDetailsPage.back()
         return navigator.navigateTo<ScheduleGridRobotScope>().apply(block)

--- a/features/schedules/schedules-ui/build.gradle.kts
+++ b/features/schedules/schedules-ui/build.gradle.kts
@@ -8,6 +8,7 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 implementation(projects.shared.resources)
+                implementation(projects.features.schedules.schedulesSemantics)
                 implementation(projects.features.schedules.schedulesUiModels)
                 implementation(projects.features.speakers.speakersUi)
                 implementation(projects.features.navigation)

--- a/features/schedules/schedules-ui/src/commonMain/kotlin/com/paligot/confily/schedules/ui/schedule/GiveFeedbackButton.kt
+++ b/features/schedules/schedules-ui/src/commonMain/kotlin/com/paligot/confily/schedules/ui/schedule/GiveFeedbackButton.kt
@@ -1,0 +1,27 @@
+package com.paligot.confily.schedules.ui.schedule
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import com.paligot.confily.resources.Resource
+import com.paligot.confily.resources.action_give_feedback
+import com.paligot.confily.schedules.semantics.SchedulesSemantics
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+fun GiveFeedbackButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Button(
+        onClick = onClick,
+        modifier = modifier
+            .fillMaxWidth()
+            .testTag(SchedulesSemantics.giveFeedbackButton)
+    ) {
+        Text(text = stringResource(Resource.string.action_give_feedback))
+    }
+}

--- a/features/schedules/schedules-ui/src/commonMain/kotlin/com/paligot/confily/schedules/ui/schedule/OpenFeedbackSection.kt
+++ b/features/schedules/schedules-ui/src/commonMain/kotlin/com/paligot/confily/schedules/ui/schedule/OpenFeedbackSection.kt
@@ -9,14 +9,18 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import com.paligot.confily.resources.Resource
+import com.paligot.confily.resources.text_openfeedback_not_started
 import com.paligot.confily.resources.text_openfeedback_title
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
 fun OpenFeedbackSection(
+    openFeedbackEnabled: Boolean,
     openFeedbackProjectId: String,
     openFeedbackSessionId: String,
+    openFeedbackUrl: String,
     canGiveFeedback: Boolean,
+    launchUrl: (String) -> Unit,
     modifier: Modifier = Modifier,
     style: TextStyle = MaterialTheme.typography.titleLarge
 ) {
@@ -28,10 +32,19 @@ fun OpenFeedbackSection(
             text = stringResource(Resource.string.text_openfeedback_title),
             style = style
         )
-        Feedback(
-            projectId = openFeedbackProjectId,
-            sessionId = openFeedbackSessionId,
-            canGiveFeedback = canGiveFeedback
-        )
+        if (openFeedbackEnabled) {
+            Feedback(
+                projectId = openFeedbackProjectId,
+                sessionId = openFeedbackSessionId,
+                canGiveFeedback = canGiveFeedback
+            )
+        } else if (canGiveFeedback) {
+            GiveFeedbackButton(onClick = { launchUrl(openFeedbackUrl) })
+        } else {
+            Text(
+                text = stringResource(Resource.string.text_openfeedback_not_started),
+                style = MaterialTheme.typography.bodyMedium
+            )
+        }
     }
 }

--- a/shared/core-db/src/commonMain/sqldelight/com/paligot/confily/db/3.sqm
+++ b/shared/core-db/src/commonMain/sqldelight/com/paligot/confily/db/3.sqm
@@ -1,0 +1,1 @@
+ALTER TABLE FeaturesActivated ADD COLUMN open_feedback_enabled INTEGER NOT NULL DEFAULT 1;

--- a/shared/core-db/src/commonMain/sqldelight/com/paligot/confily/db/FeaturesActivated.sq
+++ b/shared/core-db/src/commonMain/sqldelight/com/paligot/confily/db/FeaturesActivated.sq
@@ -9,15 +9,16 @@ has_menus INTEGER AS Boolean NOT NULL DEFAULT 0,
 has_qanda INTEGER AS Boolean NOT NULL DEFAULT 0,
 has_billet_web_ticket INTEGER AS Boolean NOT NULL DEFAULT 0,
 has_team_members INTEGER AS Boolean NOT NULL DEFAULT 0,
-has_maps INTEGER AS Boolean NOT NULL DEFAULT 0
+has_maps INTEGER AS Boolean NOT NULL DEFAULT 0,
+open_feedback_enabled INTEGER AS Boolean NOT NULL DEFAULT 1
 );
 
 insertFeatures:
 INSERT OR REPLACE INTO FeaturesActivated(
-event_id, has_networking, has_speaker_list, has_partner_list, has_menus, has_qanda, has_billet_web_ticket, has_team_members, has_maps
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);
+event_id, has_networking, has_speaker_list, has_partner_list, has_menus, has_qanda, has_billet_web_ticket, has_team_members, has_maps, open_feedback_enabled
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 selectFeatures:
-SELECT event_id, has_networking, has_speaker_list, has_partner_list, has_menus, has_qanda, has_billet_web_ticket, has_team_members, has_maps
+SELECT event_id, has_networking, has_speaker_list, has_partner_list, has_menus, has_qanda, has_billet_web_ticket, has_team_members, has_maps, open_feedback_enabled
 FROM FeaturesActivated
 WHERE event_id == ?;

--- a/shared/core/src/commonMain/kotlin/com/paligot/confily/core/events/entities/FeatureFlags.kt
+++ b/shared/core/src/commonMain/kotlin/com/paligot/confily/core/events/entities/FeatureFlags.kt
@@ -11,5 +11,6 @@ class FeatureFlags(
     val hasQAndA: Boolean,
     val hasTicketIntegration: Boolean,
     val hasTeamMembers: Boolean,
-    val hasMaps: Boolean
+    val hasMaps: Boolean,
+    val openFeedbackEnabled: Boolean
 )

--- a/shared/core/src/commonMain/kotlin/com/paligot/confily/core/schedules/SessionRepository.kt
+++ b/shared/core/src/commonMain/kotlin/com/paligot/confily/core/schedules/SessionRepository.kt
@@ -1,6 +1,7 @@
 package com.paligot.confily.core.schedules
 
 import com.paligot.confily.core.events.EventDao
+import com.paligot.confily.core.events.entities.FeatureFlags
 import com.paligot.confily.core.kvalue.ConferenceSettings
 import com.paligot.confily.core.schedules.entities.EventSession
 import com.paligot.confily.core.schedules.entities.Filters
@@ -13,6 +14,7 @@ import kotlinx.coroutines.flow.Flow
 interface SessionRepository {
     fun sessions(): Flow<Sessions>
     fun session(sessionId: String): Flow<Session>
+    fun featureFlags(): Flow<FeatureFlags>
     fun eventSession(sessionId: String): Flow<EventSession>
     fun fetchNextTalks(date: String): Flow<List<SessionItem>>
     fun filters(): Flow<Filters>

--- a/shared/core/src/commonMain/kotlin/com/paligot/confily/core/schedules/SessionRepositoryImpl.kt
+++ b/shared/core/src/commonMain/kotlin/com/paligot/confily/core/schedules/SessionRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.paligot.confily.core.schedules
 
 import com.paligot.confily.core.events.EventDao
+import com.paligot.confily.core.events.entities.FeatureFlags
 import com.paligot.confily.core.kvalue.ConferenceSettings
 import com.paligot.confily.core.schedules.entities.EventSession
 import com.paligot.confily.core.schedules.entities.Filters
@@ -43,6 +44,9 @@ class SessionRepositoryImpl(
 
     override fun session(sessionId: String): Flow<Session> = settings.fetchEventId()
         .flatMapConcat { sessionDao.fetchSession(eventId = it, sessionId = sessionId) }
+
+    override fun featureFlags(): Flow<FeatureFlags> = settings.fetchEventId()
+        .flatMapConcat { eventDao.fetchFeatureFlags(it) }
 
     override fun eventSession(sessionId: String): Flow<EventSession> =
         settings.fetchEventId()

--- a/shared/core/src/commonMain/kotlin/com/paligot/confily/core/schedules/entities/Session.kt
+++ b/shared/core/src/commonMain/kotlin/com/paligot/confily/core/schedules/entities/Session.kt
@@ -33,7 +33,7 @@ class Session(
     val feedback: FeedbackConfig?
 )
 
-fun Session.mapToSessionUi(strings: Strings): SessionUi {
+fun Session.mapToSessionUi(strings: Strings, openFeedbackEnabled: Boolean = true): SessionUi {
     val now = Clock.System.now().toLocalDateTime(TimeZone.UTC)
     val diff = endTime.toInstant(TimeZone.UTC)
         .minus(startTime.toInstant(TimeZone.UTC))
@@ -66,6 +66,7 @@ fun Session.mapToSessionUi(strings: Strings): SessionUi {
             .toImmutableList(),
         speakersSharing = speakers.joinToString(", ") { it.displayName },
         canGiveFeedback = now > startTime && feedback != null,
+        openFeedbackEnabled = openFeedbackEnabled,
         openFeedbackProjectId = feedback?.projectId,
         openFeedbackSessionId = feedback?.sessionId,
         openFeedbackUrl = feedback?.url

--- a/shared/core/src/mobileMain/kotlin/com/paligot/confily/core/events/EventDaoSQLDelight.kt
+++ b/shared/core/src/mobileMain/kotlin/com/paligot/confily/core/events/EventDaoSQLDelight.kt
@@ -105,7 +105,8 @@ class EventDaoSQLDelight(
                 hasQAndA = features?.has_qanda ?: false,
                 hasTicketIntegration = features?.has_billet_web_ticket ?: false,
                 hasTeamMembers = features?.has_team_members ?: false,
-                hasMaps = features?.has_maps ?: false
+                hasMaps = features?.has_maps ?: false,
+                openFeedbackEnabled = features?.open_feedback_enabled ?: true
             )
         }
 
@@ -198,7 +199,8 @@ class EventDaoSQLDelight(
             has_qanda = event.features.hasQAndA,
             has_billet_web_ticket = event.features.hasBilletWebTicket,
             has_team_members = event.team.isNotEmpty(),
-            has_maps = event.maps.isNotEmpty()
+            has_maps = event.maps.isNotEmpty(),
+            open_feedback_enabled = event.features.openFeedbackEnabled
         )
     }
 

--- a/shared/core/src/wasmJsMain/kotlin/com/paligot/confily/core/agenda/NetMappers.kt
+++ b/shared/core/src/wasmJsMain/kotlin/com/paligot/confily/core/agenda/NetMappers.kt
@@ -99,7 +99,8 @@ fun FeaturesActivated.convertToModelDb(
         hasQanda = hasQAndA,
         hasBilletWebTicket = hasBilletWebTicket,
         hasTeamMembers = hasTeamMembers,
-        hasMaps = hasMaps
+        hasMaps = hasMaps,
+        openFeedbackEnabled = openFeedbackEnabled
     )
 
 fun Category.convertToDb(eventId: String): CategoryDb = CategoryDb(

--- a/shared/core/src/wasmJsMain/kotlin/com/paligot/confily/core/events/DbModels.kt
+++ b/shared/core/src/wasmJsMain/kotlin/com/paligot/confily/core/events/DbModels.kt
@@ -41,7 +41,8 @@ class FeaturesActivatedDb(
     val hasQanda: Boolean,
     val hasBilletWebTicket: Boolean,
     val hasTeamMembers: Boolean,
-    val hasMaps: Boolean = false
+    val hasMaps: Boolean = false,
+    val openFeedbackEnabled: Boolean = true
 )
 
 @Serializable

--- a/shared/core/src/wasmJsMain/kotlin/com/paligot/confily/core/events/EventDaoSettings.kt
+++ b/shared/core/src/wasmJsMain/kotlin/com/paligot/confily/core/events/EventDaoSettings.kt
@@ -95,7 +95,8 @@ class EventDaoSettings(
                 hasQAndA = features?.hasQanda ?: false,
                 hasTicketIntegration = false,
                 hasTeamMembers = features?.hasTeamMembers ?: false,
-                hasMaps = features?.hasMaps ?: false
+                hasMaps = features?.hasMaps ?: false,
+                openFeedbackEnabled = features?.openFeedbackEnabled ?: true
             )
         }
 

--- a/shared/models/src/commonMain/kotlin/com/paligot/confily/models/Event.kt
+++ b/shared/models/src/commonMain/kotlin/com/paligot/confily/models/Event.kt
@@ -55,7 +55,9 @@ data class FeaturesActivated(
     @SerialName("has_qanda")
     val hasQAndA: Boolean,
     @SerialName("has_billet_web_ticket")
-    val hasBilletWebTicket: Boolean
+    val hasBilletWebTicket: Boolean,
+    @SerialName("open_feedback_enabled")
+    val openFeedbackEnabled: Boolean = true
 )
 
 @Serializable

--- a/shared/models/src/commonMain/kotlin/com/paligot/confily/models/inputs/EventInput.kt
+++ b/shared/models/src/commonMain/kotlin/com/paligot/confily/models/inputs/EventInput.kt
@@ -25,7 +25,9 @@ data class CoCInput(
 @Serializable
 data class FeaturesActivatedInput(
     @SerialName("has_networking")
-    val hasNetworking: Boolean
+    val hasNetworking: Boolean,
+    @SerialName("open_feedback_enabled")
+    val openFeedbackEnabled: Boolean = true
 ) : Validator {
     override fun validate(): List<String> = emptyList()
 }

--- a/shared/resources/src/commonMain/composeResources/values-fr/strings.xml
+++ b/shared/resources/src/commonMain/composeResources/values-fr/strings.xml
@@ -72,6 +72,7 @@
     <string name="text_speaker_activity">%1$s à %2$s</string>
 
     <string name="action_back">Retour</string>
+    <string name="action_give_feedback">Donnez votre avis</string>
     <string name="action_expanded_menu">Afficher le menu</string>
     <string name="action_share_talk">Partage la session</string>
     <string name="action_filtering">Ouvrir l'écran des filtres</string>

--- a/shared/resources/src/commonMain/composeResources/values/strings.xml
+++ b/shared/resources/src/commonMain/composeResources/values/strings.xml
@@ -72,6 +72,7 @@
     <string name="text_speaker_activity">%1$s at %2$s</string>
 
     <string name="action_back">Back</string>
+    <string name="action_give_feedback">Give your feedback</string>
     <string name="action_expanded_menu">Display overflow menu</string>
     <string name="action_share_talk">Share talk</string>
     <string name="action_filtering">Open filter screen</string>

--- a/shared/resources/src/commonMain/kotlin/com/paligot/confily/resources/Resource.kt
+++ b/shared/resources/src/commonMain/kotlin/com/paligot/confily/resources/Resource.kt
@@ -20,6 +20,7 @@ import confily.shared.resources.generated.resources.action_game_refresh
 import confily.shared.resources.generated.resources.action_game_right
 import confily.shared.resources.generated.resources.action_game_rotate
 import confily.shared.resources.generated.resources.action_generate_qrcode
+import confily.shared.resources.generated.resources.action_give_feedback
 import confily.shared.resources.generated.resources.action_networking_delete
 import confily.shared.resources.generated.resources.action_partner_video
 import confily.shared.resources.generated.resources.action_power_off
@@ -129,6 +130,10 @@ object Resource {
 @OptIn(ExperimentalResourceApi::class)
 val Resource.string.action_back: StringResource
     get() = Res.string.action_back
+
+@OptIn(ExperimentalResourceApi::class)
+val Resource.string.action_give_feedback: StringResource
+    get() = Res.string.action_give_feedback
 
 @OptIn(ExperimentalResourceApi::class)
 val Resource.string.action_contact_organizers_phone: StringResource


### PR DESCRIPTION
## Summary
- Adds a server-driven `open_feedback_enabled` feature flag (default **on**) that acts as a kill-switch for the OpenFeedback SDK on Android.
- When an admin disables it for an event, the session-detail screen shows a **"Give your feedback"** button that opens the feedback page in a Chrome Custom Tab instead of the SDK widget — no app release needed when the SDK has issues.
- The button only appears once the session has started; before that the existing "not started" message shows. iOS is unchanged (it has no OpenFeedback UI and ignores the flag).

## Changes by layer
- **Backend:** `FeatureKey.OpenFeedback` stored in `event_features` (admin-toggleable via `/features_activated`); `FeaturesActivated.open_feedback_enabled` served in all event versions (V1–V5), defaulting to `true`.
- **Persistence:** new `open_feedback_enabled` column + SQLDelight migration `3.sqm`; `FeatureFlags.openFeedbackEnabled`; mobile (`EventDaoSQLDelight`) + web (`EventDaoSettings`) read/write, default `?: true`.
- **Presentation:** `SessionRepository.featureFlags()`; `ScheduleDetailViewModel` combines the session and feature-flag streams into `SessionUi.openFeedbackEnabled`.
- **UI:** `OpenFeedbackSection` branches SDK / browser button / not-started; new `GiveFeedbackButton`; `launchUrl` threaded through the schedule nav graph.
- **Strings:** `action_give_feedback` (EN "Give your feedback", FR "Donnez votre avis").

## Test plan
- [x] `./gradlew :features:schedules:schedules-sample:desktopTest` — 3/3 incl. new `OpenFeedbackFallbackTest` (clicks the button, asserts `launchUrl` opens the exact feedback URL)
- [x] `./gradlew ktlintCheck detekt`
- [x] `./gradlew :androidApp:lintRelease` (compiles Android targets — exercises the real SDK actual + Custom Tab path)
- [ ] Manual: toggle the flag off for an event in admin; confirm the Android app shows the button and it opens the feedback page in a Custom Tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)