### PR TITLE
feat(quiz): shared quiz core — repository, networking & device id (frontend 1/4)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -188,6 +188,7 @@ ktor-client-android = { group = "io.ktor", name = "ktor-client-android", version
 ktor-client-ios = { group = "io.ktor", name = "ktor-client-ios", version.ref = "ktor" }
 ktor-client-java = { group = "io.ktor", name = "ktor-client-java", version.ref = "ktor" }
 ktor-client-js = { group = "io.ktor", name = "ktor-client-js", version.ref = "ktor" }
+ktor-client-mock = { group = "io.ktor", name = "ktor-client-mock", version.ref = "ktor" }
 
 ktor-server-core = { group = "io.ktor", name = "ktor-server-core", version.ref = "ktor" }
 ktor-server-netty = { group = "io.ktor", name = "ktor-server-netty", version.ref = "ktor" }

--- a/shared/core-api/src/commonMain/kotlin/com/paligot/confily/core/api/ConferenceApi.kt
+++ b/shared/core-api/src/commonMain/kotlin/com/paligot/confily/core/api/ConferenceApi.kt
@@ -6,15 +6,14 @@ import com.paligot.confily.models.CreatedMap
 import com.paligot.confily.models.EventList
 import com.paligot.confily.models.EventMap
 import com.paligot.confily.models.EventV5
-import com.paligot.confily.models.PartnersActivities
-import com.paligot.confily.models.inputs.MapInput
 import com.paligot.confily.models.LeaderboardEntry
+import com.paligot.confily.models.PartnersActivities
 import com.paligot.confily.models.QuizQuestion
 import com.paligot.confily.models.QuizSubmissionResult
+import com.paligot.confily.models.inputs.MapInput
 import com.paligot.confily.models.inputs.QuizPlayerInput
 import com.paligot.confily.models.inputs.QuizSubmissionInput
 import io.ktor.client.HttpClient
-import io.ktor.http.HttpStatusCode
 import io.ktor.client.call.body
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
@@ -31,6 +30,7 @@ import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.Headers
 import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json

--- a/shared/core-api/src/commonMain/kotlin/com/paligot/confily/core/api/ConferenceApi.kt
+++ b/shared/core-api/src/commonMain/kotlin/com/paligot/confily/core/api/ConferenceApi.kt
@@ -8,7 +8,13 @@ import com.paligot.confily.models.EventMap
 import com.paligot.confily.models.EventV5
 import com.paligot.confily.models.PartnersActivities
 import com.paligot.confily.models.inputs.MapInput
+import com.paligot.confily.models.LeaderboardEntry
+import com.paligot.confily.models.QuizQuestion
+import com.paligot.confily.models.QuizSubmissionResult
+import com.paligot.confily.models.inputs.QuizPlayerInput
+import com.paligot.confily.models.inputs.QuizSubmissionInput
 import io.ktor.client.HttpClient
+import io.ktor.http.HttpStatusCode
 import io.ktor.client.call.body
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
@@ -114,6 +120,39 @@ class ConferenceApi(
             )
         )
     }.body()
+
+    suspend fun registerQuizPlayer(eventId: String, input: QuizPlayerInput) {
+        client.post("$baseUrl/events/$eventId/quiz/players") {
+            contentType(ContentType.Application.Json)
+            setBody(input)
+        }
+    }
+
+    suspend fun fetchQuizQuestions(eventId: String, code: String): List<QuizQuestion> {
+        val response = client.get("$baseUrl/events/$eventId/quiz/partners/$code")
+        if (response.status == HttpStatusCode.NotFound) throw QuizException.CodeNotFound(code)
+        return response.body()
+    }
+
+    suspend fun submitQuiz(
+        eventId: String,
+        code: String,
+        input: QuizSubmissionInput
+    ): QuizSubmissionResult {
+        val response = client.post("$baseUrl/events/$eventId/quiz/partners/$code/submit") {
+            contentType(ContentType.Application.Json)
+            setBody(input)
+        }
+        when (response.status) {
+            HttpStatusCode.Conflict -> throw QuizException.AlreadySubmitted()
+            HttpStatusCode.NotFound -> throw QuizException.PlayerNotRegistered()
+            else -> Unit
+        }
+        return response.body()
+    }
+
+    suspend fun fetchQuizLeaderboard(eventId: String): List<LeaderboardEntry> =
+        client.get("$baseUrl/events/$eventId/quiz/leaderboard").body()
 
     companion object {
         fun create(

--- a/shared/core-api/src/commonMain/kotlin/com/paligot/confily/core/api/QuizException.kt
+++ b/shared/core-api/src/commonMain/kotlin/com/paligot/confily/core/api/QuizException.kt
@@ -1,0 +1,7 @@
+package com.paligot.confily.core.api
+
+sealed class QuizException(message: String) : Exception(message) {
+    class CodeNotFound(code: String) : QuizException("No quiz found for code $code")
+    class AlreadySubmitted : QuizException("Answers already submitted for this quiz")
+    class PlayerNotRegistered : QuizException("Player not registered for this device")
+}

--- a/shared/core-di/src/androidMain/kotlin/com/paligot/confily/core/di/AndroidPlatformModule.kt
+++ b/shared/core-di/src/androidMain/kotlin/com/paligot/confily/core/di/AndroidPlatformModule.kt
@@ -1,6 +1,8 @@
 package com.paligot.confily.core.di
 
 import android.content.Context
+import com.paligot.confily.core.DeviceIdProvider
+import com.paligot.confily.core.DeviceIdProviderAndroid
 import com.paligot.confily.core.Platform
 import com.paligot.confily.core.QrCodeGenerator
 import com.paligot.confily.core.QrCodeGeneratorAndroid
@@ -33,4 +35,5 @@ actual val platformModule = module {
     }
     single<String>(named(AcceptLanguageNamed)) { Locale.getDefault().toLanguageTag() }
     single<QrCodeGenerator> { QrCodeGeneratorAndroid() }
+    single<DeviceIdProvider> { DeviceIdProviderAndroid(androidContext()) }
 }

--- a/shared/core-di/src/commonMain/kotlin/com/paligot/confily/core/di/RepositoryModule.kt
+++ b/shared/core-di/src/commonMain/kotlin/com/paligot/confily/core/di/RepositoryModule.kt
@@ -4,6 +4,7 @@ import com.paligot.confily.core.events.EventRepository
 import com.paligot.confily.core.maps.MapRepository
 import com.paligot.confily.core.networking.UserRepository
 import com.paligot.confily.core.partners.PartnerRepository
+import com.paligot.confily.core.quiz.QuizRepository
 import com.paligot.confily.core.schedules.SessionRepository
 import com.paligot.confily.core.speakers.SpeakerRepository
 import org.koin.dsl.module
@@ -54,6 +55,13 @@ val repositoriesModule = module {
         MapRepository.Factory.create(
             settings = get(),
             mapDao = get()
+        )
+    }
+    single {
+        QuizRepository.Factory.create(
+            api = get(),
+            settings = get(),
+            deviceIdProvider = get()
         )
     }
 }

--- a/shared/core-di/src/desktopMain/kotlin/com/paligot/confily/core/di/PlatformModule.desktop.kt
+++ b/shared/core-di/src/desktopMain/kotlin/com/paligot/confily/core/di/PlatformModule.desktop.kt
@@ -1,6 +1,8 @@
 package com.paligot.confily.core.di
 
 import com.paligot.confily.core.AlarmScheduler
+import com.paligot.confily.core.DeviceIdProvider
+import com.paligot.confily.core.DeviceIdProviderDesktop
 import com.paligot.confily.core.Platform
 import com.paligot.confily.core.QrCodeGenerator
 import com.paligot.confily.core.QrCodeGeneratorJvm
@@ -22,4 +24,5 @@ actual val platformModule = module {
     single<String>(named(AcceptLanguageNamed)) { Locale.getDefault().toLanguageTag() }
     single<QrCodeGenerator> { QrCodeGeneratorJvm() }
     single<AlarmScheduler> { AlarmScheduler(repository = get()) }
+    single<DeviceIdProvider> { DeviceIdProviderDesktop() }
 }

--- a/shared/core-di/src/iosMain/kotlin/com/paligot/confily/core/di/Helper.kt
+++ b/shared/core-di/src/iosMain/kotlin/com/paligot/confily/core/di/Helper.kt
@@ -7,6 +7,7 @@ import com.paligot.confily.core.networking.UserInteractor
 import com.paligot.confily.core.networking.UserRepository
 import com.paligot.confily.core.partners.PartnerInteractor
 import com.paligot.confily.core.partners.PartnerRepository
+import com.paligot.confily.core.quiz.QuizRepository
 import com.paligot.confily.core.schedules.SessionRepository
 import com.paligot.confily.core.sessions.SessionInteractor
 import com.paligot.confily.core.speakers.SpeakerInteractor
@@ -35,6 +36,7 @@ class RepositoryHelper : KoinComponent {
     val eventRepository: EventRepository by inject()
     val speakerRepository: SpeakerRepository by inject()
     val userRepository: UserRepository by inject()
+    val quizRepository: QuizRepository by inject()
 }
 
 class InteractorHelper : KoinComponent {

--- a/shared/core-di/src/iosMain/kotlin/com/paligot/confily/core/di/IOSPlatformModule.kt
+++ b/shared/core-di/src/iosMain/kotlin/com/paligot/confily/core/di/IOSPlatformModule.kt
@@ -1,5 +1,7 @@
 package com.paligot.confily.core.di
 
+import com.paligot.confily.core.DeviceIdProvider
+import com.paligot.confily.core.DeviceIdProviderIos
 import com.paligot.confily.core.Platform
 import com.paligot.confily.core.QrCodeGenerator
 import com.paligot.confily.core.QrCodeGeneratoriOS
@@ -23,4 +25,5 @@ actual val platformModule = module {
     single<ObservableSettings> { NSUserDefaultsSettings(standardUserDefaults) }
     single<String>(named(AcceptLanguageNamed)) { NSLocale.preferredLanguages.first().toString() }
     single<QrCodeGenerator> { QrCodeGeneratoriOS() }
+    single<DeviceIdProvider> { DeviceIdProviderIos() }
 }

--- a/shared/core-di/src/wasmJsMain/kotlin/com/paligot/confily/core/di/PlatformModule.wasmJs.kt
+++ b/shared/core-di/src/wasmJsMain/kotlin/com/paligot/confily/core/di/PlatformModule.wasmJs.kt
@@ -1,5 +1,7 @@
 package com.paligot.confily.core.di
 
+import com.paligot.confily.core.DeviceIdProvider
+import com.paligot.confily.core.DeviceIdProviderWasmJs
 import com.paligot.confily.core.Platform
 import com.paligot.confily.core.QrCodeGenerator
 import com.paligot.confily.core.QrCodeGeneratorWasm
@@ -21,4 +23,5 @@ actual val platformModule: Module = module {
         navigatorLanguage().unsafeCast<JsString>().toString()
     }
     single<QrCodeGenerator> { QrCodeGeneratorWasm() }
+    single<DeviceIdProvider> { DeviceIdProviderWasmJs() }
 }

--- a/shared/core-kvalue/src/commonMain/kotlin/com/paligot/confily/core/kvalue/ConferenceSettings.kt
+++ b/shared/core-kvalue/src/commonMain/kotlin/com/paligot/confily/core/kvalue/ConferenceSettings.kt
@@ -27,4 +27,18 @@ class ConferenceSettings(
 
     fun upsertOnlyFavoritesFlag(onlyFavorites: Boolean) =
         settings.putBoolean("ONLY_FAVORITES", onlyFavorites)
+
+    fun getQuizDeviceId(): String? = settings.getStringOrNull("QUIZ_DEVICE_ID")
+
+    fun putQuizDeviceId(deviceId: String) = settings.putString("QUIZ_DEVICE_ID", deviceId)
+
+    fun fetchQuizUsername(): Flow<String?> = settings.getStringOrNullFlow("QUIZ_USERNAME")
+
+    fun getQuizUsername(): String? = settings.getStringOrNull("QUIZ_USERNAME")
+
+    fun putQuizUsername(username: String) = settings.putString("QUIZ_USERNAME", username)
+
+    fun getQuizResults(): String? = settings.getStringOrNull("QUIZ_RESULTS")
+
+    fun putQuizResults(resultsJson: String) = settings.putString("QUIZ_RESULTS", resultsJson)
 }

--- a/shared/core/build.gradle.kts
+++ b/shared/core/build.gradle.kts
@@ -84,6 +84,8 @@ kotlin {
                 implementation(libs.jetbrains.kotlinx.coroutines.test)
                 implementation(libs.settings.test)
                 implementation(libs.ktor.client.mock)
+                implementation(libs.ktor.client.negotiation)
+                implementation(libs.ktor.serialization.json)
             }
         }
         val mobileMain by creating {

--- a/shared/core/build.gradle.kts
+++ b/shared/core/build.gradle.kts
@@ -75,6 +75,15 @@ kotlin {
                 api(libs.jetbrains.kotlinx.coroutines)
 
                 implementation(libs.lyricist)
+                implementation(libs.jetbrains.kotlinx.serialization.json)
+            }
+        }
+        val commonTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+                implementation(libs.jetbrains.kotlinx.coroutines.test)
+                implementation(libs.settings.test)
+                implementation(libs.ktor.client.mock)
             }
         }
         val mobileMain by creating {
@@ -104,11 +113,6 @@ kotlin {
         val desktopMain by getting {
             dependsOn(commonMain)
             dependsOn(mobileMain)
-        }
-        wasmJsMain {
-            dependencies {
-                implementation(libs.jetbrains.kotlinx.serialization.json)
-            }
         }
     }
 

--- a/shared/core/src/androidMain/kotlin/com/paligot/confily/core/DeviceIdProviderAndroid.kt
+++ b/shared/core/src/androidMain/kotlin/com/paligot/confily/core/DeviceIdProviderAndroid.kt
@@ -1,0 +1,19 @@
+package com.paligot.confily.core
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.provider.Settings
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+class DeviceIdProviderAndroid(private val context: Context) : DeviceIdProvider {
+    @OptIn(ExperimentalUuidApi::class)
+    @SuppressLint("HardwareIds")
+    override fun deviceId(): String {
+        val androidId = Settings.Secure.getString(
+            context.contentResolver,
+            Settings.Secure.ANDROID_ID
+        )
+        return if (androidId.isNullOrBlank()) Uuid.random().toString() else androidId
+    }
+}

--- a/shared/core/src/commonMain/kotlin/com/paligot/confily/core/DeviceIdProvider.kt
+++ b/shared/core/src/commonMain/kotlin/com/paligot/confily/core/DeviceIdProvider.kt
@@ -1,0 +1,6 @@
+package com.paligot.confily.core
+
+interface DeviceIdProvider {
+    /** Returns a non-blank, best-effort stable identifier for this device/install. */
+    fun deviceId(): String
+}

--- a/shared/core/src/commonMain/kotlin/com/paligot/confily/core/quiz/QuizRepository.kt
+++ b/shared/core/src/commonMain/kotlin/com/paligot/confily/core/quiz/QuizRepository.kt
@@ -1,0 +1,26 @@
+package com.paligot.confily.core.quiz
+
+import com.paligot.confily.core.DeviceIdProvider
+import com.paligot.confily.core.api.ConferenceApi
+import com.paligot.confily.core.kvalue.ConferenceSettings
+import com.paligot.confily.models.QuizQuestion
+import com.paligot.confily.models.QuizSubmissionResult
+import com.paligot.confily.models.inputs.QuizAnswerInput
+import kotlinx.coroutines.flow.Flow
+
+interface QuizRepository {
+    suspend fun register(username: String)
+    fun storedUsername(): Flow<String?>
+    suspend fun questions(code: String): List<QuizQuestion>
+    suspend fun submit(code: String, answers: List<QuizAnswerInput>): QuizSubmissionResult
+    fun savedResult(code: String): QuizSubmissionResult?
+    suspend fun cumulativeScore(): Int?
+
+    object Factory {
+        fun create(
+            api: ConferenceApi,
+            settings: ConferenceSettings,
+            deviceIdProvider: DeviceIdProvider
+        ): QuizRepository = QuizRepositoryImpl(api, settings, deviceIdProvider)
+    }
+}

--- a/shared/core/src/commonMain/kotlin/com/paligot/confily/core/quiz/QuizRepositoryImpl.kt
+++ b/shared/core/src/commonMain/kotlin/com/paligot/confily/core/quiz/QuizRepositoryImpl.kt
@@ -1,0 +1,70 @@
+package com.paligot.confily.core.quiz
+
+import com.paligot.confily.core.DeviceIdProvider
+import com.paligot.confily.core.api.ConferenceApi
+import com.paligot.confily.core.kvalue.ConferenceSettings
+import com.paligot.confily.models.QuizQuestion
+import com.paligot.confily.models.QuizSubmissionResult
+import com.paligot.confily.models.inputs.QuizAnswerInput
+import com.paligot.confily.models.inputs.QuizPlayerInput
+import com.paligot.confily.models.inputs.QuizSubmissionInput
+import kotlinx.coroutines.flow.Flow
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+internal class QuizRepositoryImpl(
+    private val api: ConferenceApi,
+    private val settings: ConferenceSettings,
+    private val deviceIdProvider: DeviceIdProvider
+) : QuizRepository {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    override suspend fun register(username: String) {
+        val eventId = settings.getEventId()
+        api.registerQuizPlayer(
+            eventId = eventId,
+            input = QuizPlayerInput(username = username, deviceId = deviceId())
+        )
+        settings.putQuizUsername(username)
+    }
+
+    override fun storedUsername(): Flow<String?> = settings.fetchQuizUsername()
+
+    override suspend fun questions(code: String): List<QuizQuestion> =
+        api.fetchQuizQuestions(eventId = settings.getEventId(), code = code)
+
+    override suspend fun submit(
+        code: String,
+        answers: List<QuizAnswerInput>
+    ): QuizSubmissionResult {
+        val result = api.submitQuiz(
+            eventId = settings.getEventId(),
+            code = code,
+            input = QuizSubmissionInput(deviceId = deviceId(), answers = answers)
+        )
+        saveResult(code, result)
+        return result
+    }
+
+    override fun savedResult(code: String): QuizSubmissionResult? = readResults()[code]
+
+    override suspend fun cumulativeScore(): Int? {
+        val username = settings.getQuizUsername() ?: return null
+        return api.fetchQuizLeaderboard(settings.getEventId())
+            .firstOrNull { it.username == username }
+            ?.score
+    }
+
+    private fun deviceId(): String =
+        settings.getQuizDeviceId() ?: deviceIdProvider.deviceId().also { settings.putQuizDeviceId(it) }
+
+    private fun readResults(): Map<String, QuizSubmissionResult> =
+        settings.getQuizResults()?.let {
+            runCatching { json.decodeFromString<Map<String, QuizSubmissionResult>>(it) }.getOrNull()
+        } ?: emptyMap()
+
+    private fun saveResult(code: String, result: QuizSubmissionResult) {
+        val updated = readResults() + (code to result)
+        settings.putQuizResults(json.encodeToString(updated))
+    }
+}

--- a/shared/core/src/commonTest/kotlin/com/paligot/confily/core/SmokeTest.kt
+++ b/shared/core/src/commonTest/kotlin/com/paligot/confily/core/SmokeTest.kt
@@ -1,0 +1,11 @@
+package com.paligot.confily.core
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SmokeTest {
+    @Test
+    fun commonTest_source_set_runs() {
+        assertEquals(4, 2 + 2)
+    }
+}

--- a/shared/core/src/commonTest/kotlin/com/paligot/confily/core/quiz/FakeDeviceIdProvider.kt
+++ b/shared/core/src/commonTest/kotlin/com/paligot/confily/core/quiz/FakeDeviceIdProvider.kt
@@ -1,0 +1,13 @@
+package com.paligot.confily.core.quiz
+
+import com.paligot.confily.core.DeviceIdProvider
+
+class FakeDeviceIdProvider(private val id: String = "device-1") : DeviceIdProvider {
+    var callCount: Int = 0
+        private set
+
+    override fun deviceId(): String {
+        callCount++
+        return id
+    }
+}

--- a/shared/core/src/commonTest/kotlin/com/paligot/confily/core/quiz/QuizApiTestSupport.kt
+++ b/shared/core/src/commonTest/kotlin/com/paligot/confily/core/quiz/QuizApiTestSupport.kt
@@ -1,0 +1,41 @@
+package com.paligot.confily.core.quiz
+
+import com.paligot.confily.core.api.ConferenceApi
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.json.Json
+
+private val jsonHeaders = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+
+class RecordingResponder {
+    val requestedPaths = mutableListOf<String>()
+    val requestBodies = mutableListOf<String>()
+    val routes = mutableMapOf<String, Pair<HttpStatusCode, String>>()
+
+    fun on(pathSuffix: String, status: HttpStatusCode = HttpStatusCode.OK, body: String = "") {
+        routes[pathSuffix] = status to body
+    }
+}
+
+fun conferenceApiWith(responder: RecordingResponder): ConferenceApi {
+    val engine = MockEngine { request ->
+        responder.requestedPaths.add(request.url.encodedPath)
+        responder.requestBodies.add((request.body as? io.ktor.http.content.TextContent)?.text ?: "")
+        val match = responder.routes.entries.firstOrNull { request.url.encodedPath.endsWith(it.key) }
+            ?: error("No mock route for ${request.url.encodedPath}")
+        respond(content = match.value.second, status = match.value.first, headers = jsonHeaders)
+    }
+    val client = HttpClient(engine) {
+        install(ContentNegotiation) {
+            json(Json { isLenient = true; ignoreUnknownKeys = true })
+        }
+    }
+    return ConferenceApi(client = client, baseUrl = "https://test.local")
+}

--- a/shared/core/src/commonTest/kotlin/com/paligot/confily/core/quiz/QuizRepositoryTest.kt
+++ b/shared/core/src/commonTest/kotlin/com/paligot/confily/core/quiz/QuizRepositoryTest.kt
@@ -1,0 +1,145 @@
+package com.paligot.confily.core.quiz
+
+import com.paligot.confily.core.api.QuizException
+import com.paligot.confily.core.kvalue.ConferenceSettings
+import com.paligot.confily.models.inputs.QuizAnswerInput
+import com.russhwolf.settings.MapSettings
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class QuizRepositoryTest {
+    private fun settingsWithEvent(): ConferenceSettings =
+        ConferenceSettings(MapSettings()).apply { insertEventId("event-1") }
+
+    private val questionsJson = """
+        [{"id":"q1","order":0,"question":"Capital of France?","options":[
+          {"id":"a1","label":"Paris","order":0},{"id":"a2","label":"Lyon","order":1}]}]
+    """.trimIndent()
+
+    private val submissionResultJson = """
+        {"correct_count":1,"total_count":1,"per_question":[
+          {"question_id":"q1","chosen_answer_id":"a1","correct_answer_id":"a1","is_correct":true}]}
+    """.trimIndent()
+
+    @Test
+    fun register_persists_username_and_posts_player() = runTest {
+        val responder = RecordingResponder().apply { on("/quiz/players", HttpStatusCode.Created, """{"id":"p1"}""") }
+        val settings = settingsWithEvent()
+        val provider = FakeDeviceIdProvider("device-1")
+        val repo = QuizRepository.Factory.create(conferenceApiWith(responder), settings, provider)
+
+        repo.register("Alice")
+
+        assertEquals("Alice", settings.getQuizUsername())
+        assertEquals("device-1", settings.getQuizDeviceId())
+        assertTrue(responder.requestedPaths.any { it.endsWith("/quiz/players") })
+        assertTrue(responder.requestBodies.any { it.contains("Alice") && it.contains("device-1") })
+    }
+
+    @Test
+    fun questions_returns_parsed_list() = runTest {
+        val responder = RecordingResponder().apply { on("/quiz/partners/ABCD", HttpStatusCode.OK, questionsJson) }
+        val repo = QuizRepository.Factory.create(conferenceApiWith(responder), settingsWithEvent(), FakeDeviceIdProvider())
+
+        val questions = repo.questions("ABCD")
+
+        assertEquals(1, questions.size)
+        assertEquals("Capital of France?", questions[0].question)
+        assertEquals(listOf("Paris", "Lyon"), questions[0].options.map { it.label })
+    }
+
+    @Test
+    fun questions_maps_404_to_CodeNotFound() = runTest {
+        val responder = RecordingResponder().apply { on("/quiz/partners/ZZZZ", HttpStatusCode.NotFound, "") }
+        val repo = QuizRepository.Factory.create(conferenceApiWith(responder), settingsWithEvent(), FakeDeviceIdProvider())
+
+        assertFailsWith<QuizException.CodeNotFound> { repo.questions("ZZZZ") }
+    }
+
+    @Test
+    fun submit_returns_result_and_persists_it() = runTest {
+        val responder = RecordingResponder().apply {
+            on("/quiz/partners/ABCD/submit", HttpStatusCode.Created, submissionResultJson)
+        }
+        val settings = settingsWithEvent()
+        val repo = QuizRepository.Factory.create(conferenceApiWith(responder), settings, FakeDeviceIdProvider())
+
+        val result = repo.submit("ABCD", listOf(QuizAnswerInput("q1", "a1")))
+
+        assertEquals(1, result.correctCount)
+        assertEquals(1, result.totalCount)
+        assertEquals(result.correctCount, repo.savedResult("ABCD")?.correctCount)
+    }
+
+    @Test
+    fun submit_maps_409_to_AlreadySubmitted() = runTest {
+        val responder = RecordingResponder().apply { on("/quiz/partners/ABCD/submit", HttpStatusCode.Conflict, "") }
+        val repo = QuizRepository.Factory.create(conferenceApiWith(responder), settingsWithEvent(), FakeDeviceIdProvider())
+
+        assertFailsWith<QuizException.AlreadySubmitted> { repo.submit("ABCD", listOf(QuizAnswerInput("q1", "a1"))) }
+    }
+
+    @Test
+    fun savedResult_is_null_before_submission() = runTest {
+        val repo = QuizRepository.Factory.create(conferenceApiWith(RecordingResponder()), settingsWithEvent(), FakeDeviceIdProvider())
+        assertNull(repo.savedResult("ABCD"))
+    }
+
+    @Test
+    fun cumulativeScore_matches_stored_username() = runTest {
+        val responder = RecordingResponder().apply {
+            on("/quiz/leaderboard", HttpStatusCode.OK, """[{"rank":1,"username":"Bob","score":9},{"rank":2,"username":"Alice","score":4}]""")
+        }
+        val settings = settingsWithEvent().apply { putQuizUsername("Alice") }
+        val repo = QuizRepository.Factory.create(conferenceApiWith(responder), settings, FakeDeviceIdProvider())
+
+        assertEquals(4, repo.cumulativeScore())
+    }
+
+    @Test
+    fun cumulativeScore_is_null_when_user_not_in_leaderboard() = runTest {
+        val responder = RecordingResponder().apply { on("/quiz/leaderboard", HttpStatusCode.OK, "[]") }
+        val settings = settingsWithEvent().apply { putQuizUsername("Alice") }
+        val repo = QuizRepository.Factory.create(conferenceApiWith(responder), settings, FakeDeviceIdProvider())
+
+        assertNull(repo.cumulativeScore())
+    }
+
+    @Test
+    fun cumulativeScore_is_null_when_no_username_stored() = runTest {
+        val repo = QuizRepository.Factory.create(
+            conferenceApiWith(RecordingResponder()),
+            settingsWithEvent(),
+            FakeDeviceIdProvider()
+        )
+        assertNull(repo.cumulativeScore())
+    }
+
+    @Test
+    fun savedResult_returns_null_for_corrupt_stored_results() = runTest {
+        val settings = settingsWithEvent().apply { putQuizResults("not-valid-json") }
+        val repo = QuizRepository.Factory.create(conferenceApiWith(RecordingResponder()), settings, FakeDeviceIdProvider())
+        assertNull(repo.savedResult("ABCD"))
+    }
+
+    @Test
+    fun deviceId_is_reused_after_first_registration() = runTest {
+        val responder = RecordingResponder().apply {
+            on("/quiz/players", HttpStatusCode.Created, """{"id":"p1"}""")
+            on("/quiz/partners/ABCD/submit", HttpStatusCode.Created, submissionResultJson)
+        }
+        val settings = settingsWithEvent()
+        val provider = FakeDeviceIdProvider("device-1")
+        val repo = QuizRepository.Factory.create(conferenceApiWith(responder), settings, provider)
+
+        repo.register("Alice")
+        repo.submit("ABCD", listOf(QuizAnswerInput("q1", "a1")))
+
+        assertEquals(1, provider.callCount)
+    }
+}

--- a/shared/core/src/commonTest/kotlin/com/paligot/confily/core/quiz/QuizRepositoryTest.kt
+++ b/shared/core/src/commonTest/kotlin/com/paligot/confily/core/quiz/QuizRepositoryTest.kt
@@ -85,6 +85,14 @@ class QuizRepositoryTest {
     }
 
     @Test
+    fun submit_maps_404_to_PlayerNotRegistered() = runTest {
+        val responder = RecordingResponder().apply { on("/quiz/partners/ABCD/submit", HttpStatusCode.NotFound, "") }
+        val repo = QuizRepository.Factory.create(conferenceApiWith(responder), settingsWithEvent(), FakeDeviceIdProvider())
+
+        assertFailsWith<QuizException.PlayerNotRegistered> { repo.submit("ABCD", listOf(QuizAnswerInput("q1", "a1"))) }
+    }
+
+    @Test
     fun savedResult_is_null_before_submission() = runTest {
         val repo = QuizRepository.Factory.create(conferenceApiWith(RecordingResponder()), settingsWithEvent(), FakeDeviceIdProvider())
         assertNull(repo.savedResult("ABCD"))

--- a/shared/core/src/desktopMain/kotlin/com/paligot/confily/core/DeviceIdProviderDesktop.kt
+++ b/shared/core/src/desktopMain/kotlin/com/paligot/confily/core/DeviceIdProviderDesktop.kt
@@ -1,0 +1,9 @@
+package com.paligot.confily.core
+
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+class DeviceIdProviderDesktop : DeviceIdProvider {
+    @OptIn(ExperimentalUuidApi::class)
+    override fun deviceId(): String = Uuid.random().toString()
+}

--- a/shared/core/src/iosMain/kotlin/com/paligot/confily/core/DeviceIdProviderIos.kt
+++ b/shared/core/src/iosMain/kotlin/com/paligot/confily/core/DeviceIdProviderIos.kt
@@ -1,0 +1,11 @@
+package com.paligot.confily.core
+
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+import platform.UIKit.UIDevice
+
+class DeviceIdProviderIos : DeviceIdProvider {
+    @OptIn(ExperimentalUuidApi::class)
+    override fun deviceId(): String =
+        UIDevice.currentDevice.identifierForVendor?.UUIDString ?: Uuid.random().toString()
+}

--- a/shared/core/src/iosMain/kotlin/com/paligot/confily/core/DeviceIdProviderIos.kt
+++ b/shared/core/src/iosMain/kotlin/com/paligot/confily/core/DeviceIdProviderIos.kt
@@ -1,8 +1,8 @@
 package com.paligot.confily.core
 
+import platform.UIKit.UIDevice
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
-import platform.UIKit.UIDevice
 
 class DeviceIdProviderIos : DeviceIdProvider {
     @OptIn(ExperimentalUuidApi::class)

--- a/shared/core/src/wasmJsMain/kotlin/com/paligot/confily/core/DeviceIdProviderWasmJs.kt
+++ b/shared/core/src/wasmJsMain/kotlin/com/paligot/confily/core/DeviceIdProviderWasmJs.kt
@@ -1,0 +1,9 @@
+package com.paligot.confily.core
+
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+class DeviceIdProviderWasmJs : DeviceIdProvider {
+    @OptIn(ExperimentalUuidApi::class)
+    override fun deviceId(): String = Uuid.random().toString()
+}


### PR DESCRIPTION
## Summary
First of four PRs implementing the Quiz frontend feature. This one adds the **shared KMP core** that the Android (Compose) and iOS (SwiftUI) UIs will build on — no UI yet.

- Shared, unit-tested `QuizRepository` (`shared/core`): register player, fetch questions by partner code, submit answers, persist per-quiz results locally, and compute the player's cumulative score from the leaderboard (rank intentionally discarded).
- Four quiz endpoints on `ConferenceApi` with typed `QuizException` mapping: questions 404 → `CodeNotFound`; submit 409 → `AlreadySubmitted`, 404 → `PlayerNotRegistered`.
- `DeviceIdProvider` from the platform SDK (Android `ANDROID_ID`, iOS `identifierForVendor`, desktop/wasmJs UUID), following the existing `QrCodeGenerator` interface + per-platform Koin binding pattern. The id is persisted via `ConferenceSettings` so it stays stable.
- Quiz persistence keys (`device id`, `username`, results JSON) on `ConferenceSettings`.
- Koin DI wiring: `QuizRepository` in `repositoriesModule`, `DeviceIdProvider` bound in all four platform modules, and `quizRepository` exposed on the iOS `RepositoryHelper`.
- Introduces the first `commonTest` source set in `shared/core` (12 unit tests via Ktor `MockEngine` + `MapSettings`).

## Scope
Part 1 of 4 (shared core). The `hasQuiz` feature flag, Android UI, and iOS UI follow in subsequent PRs. No backend changes (the quiz API already shipped).

## Test Plan
- [x] `./gradlew :shared:core:desktopTest` — 12 `QuizRepositoryTest` + 1 smoke test pass
- [x] ktlint + detekt clean on `shared/core`, `core-api`, `core-kvalue`, `core-di`
- [x] Compiles on android, iOS (simulatorArm64), desktop, wasmJs

🤖 Generated with [Claude Code](https://claude.com/claude-code)