### PR TITLE
feat(quiz): iOS Quiz UI — tab, code entry, questions, result (frontend 4/4)

### DIFF
--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -30,6 +30,8 @@
 		058557D9273AAEEB004C7B11 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 058557D8273AAEEB004C7B11 /* Preview Assets.xcassets */; };
 		2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2152FB032600AC8F00CF470E /* iOSApp.swift */; };
 		7555FF83242A565900829871 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7555FF82242A565900829871 /* HomeView.swift */; };
+		95AA0761973DAFB131677D49 /* QuizViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B518C97B2FECA9591F473891 /* QuizViewModel.swift */; };
+		9F4CCDE3D6529F0435C6FF80 /* QuizScreens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 705AB1DA91E69A41F15806D8 /* QuizScreens.swift */; };
 		D501315A27C038BB001B48A5 /* ProfileInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D501315927C038BB001B48A5 /* ProfileInputView.swift */; };
 		D50A458F27B081B600C9A43C /* Agenda.swift in Sources */ = {isa = PBXBuildFile; fileRef = D50A458E27B081B600C9A43C /* Agenda.swift */; };
 		D50E9B0327C12AE400B7B9B9 /* NetworkingVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = D50E9B0227C12AE400B7B9B9 /* NetworkingVM.swift */; };
@@ -155,9 +157,11 @@
 		058557BA273AAA24004C7B11 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		058557D8273AAEEB004C7B11 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		2152FB032600AC8F00CF470E /* iOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSApp.swift; sourceTree = "<group>"; };
+		705AB1DA91E69A41F15806D8 /* QuizScreens.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = QuizScreens.swift; sourceTree = "<group>"; };
 		7555FF7B242A565900829871 /* iosApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iosApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7555FF82242A565900829871 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		7555FF8C242A565B00829871 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		B518C97B2FECA9591F473891 /* QuizViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = QuizViewModel.swift; sourceTree = "<group>"; };
 		D501315927C038BB001B48A5 /* ProfileInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileInputView.swift; sourceTree = "<group>"; };
 		D50A458E27B081B600C9A43C /* Agenda.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Agenda.swift; sourceTree = "<group>"; };
 		D50E9B0227C12AE400B7B9B9 /* NetworkingVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkingVM.swift; sourceTree = "<group>"; };
@@ -241,7 +245,17 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		F535A2BE2F3A986F00148F86 /* Scripts */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Scripts; sourceTree = "<group>"; };
+		F535A2BE2F3A986F00148F86 /* Scripts */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = Scripts;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -317,6 +331,15 @@
 				058557D8273AAEEB004C7B11 /* Preview Assets.xcassets */,
 			);
 			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		22646CDF337DA988EA19DA07 /* quiz */ = {
+			isa = PBXGroup;
+			children = (
+				B518C97B2FECA9591F473891 /* QuizViewModel.swift */,
+				705AB1DA91E69A41F15806D8 /* QuizScreens.swift */,
+			);
+			path = quiz;
 			sourceTree = "<group>";
 		};
 		7555FF72242A565900829871 = {
@@ -424,6 +447,7 @@
 				D524D73A27BBFBA60078DF0D /* schedule */,
 				D57028AB27B55345008EF4AD /* event */,
 				D5D6166A27B15C3C00C59EC9 /* agenda */,
+				22646CDF337DA988EA19DA07 /* quiz */,
 			);
 			path = screens;
 			sourceTree = "<group>";
@@ -937,6 +961,8 @@
 				D55D7A75295F83D9008EA04B /* PartnerDetailView.swift in Sources */,
 				7555FF83242A565900829871 /* HomeView.swift in Sources */,
 				D57028AD27B5535F008EF4AD /* Event.swift in Sources */,
+				95AA0761973DAFB131677D49 /* QuizViewModel.swift in Sources */,
+				9F4CCDE3D6529F0435C6FF80 /* QuizScreens.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iosApp/iosApp/ViewModelFactory.swift
+++ b/iosApp/iosApp/ViewModelFactory.swift
@@ -51,6 +51,10 @@ class ViewModelFactory: ObservableObject {
         return PartnersViewModel()
     }
 
+    func makeQuizViewModel() -> QuizViewModel {
+        return QuizViewModel()
+    }
+
     func makePartnerDetailViewModel(partnerId: String) -> PartnerDetailViewModel {
         return PartnerDetailViewModel(partnerId: partnerId)
     }

--- a/iosApp/iosApp/en.lproj/Localizable.strings
+++ b/iosApp/iosApp/en.lproj/Localizable.strings
@@ -121,3 +121,15 @@
 "semanticTalkItemTime" = "during %d minutes";
 "semanticTalkItemCategory" = "in category %@";
 "semanticTalkItemLevel" = "for level %@";
+
+"screenQuiz" = "Quiz";
+"quizEnterCodeTitle" = "Enter the partner code";
+"quizCodeLabel" = "Partner code";
+"quizNameLabel" = "Your name";
+"quizActionStart" = "Start";
+"quizActionSubmit" = "Submit";
+"quizActionBackToCode" = "Enter another code";
+"quizScoreLabel" = "Your score: %d";
+"quizResultScore" = "%d / %d correct";
+"quizAlreadyCompleted" = "You have already completed this quiz.";
+"quizErrorCodeNotFound" = "No quiz found for this code.";

--- a/iosApp/iosApp/fr.lproj/Localizable.strings
+++ b/iosApp/iosApp/fr.lproj/Localizable.strings
@@ -120,3 +120,15 @@
 "semanticTalkItemTime" = "pendant %d minutes";
 "semanticTalkItemCategory" = "dans la categorie %@";
 "semanticTalkItemLevel" = "pour niveau %@";
+
+"screenQuiz" = "Quiz";
+"quizEnterCodeTitle" = "Entrez le code partenaire";
+"quizCodeLabel" = "Code partenaire";
+"quizNameLabel" = "Votre nom";
+"quizActionStart" = "Commencer";
+"quizActionSubmit" = "Valider";
+"quizActionBackToCode" = "Saisir un autre code";
+"quizScoreLabel" = "Votre score : %d";
+"quizResultScore" = "%d / %d correctes";
+"quizAlreadyCompleted" = "Vous avez déjà terminé ce quiz.";
+"quizErrorCodeNotFound" = "Aucun quiz trouvé pour ce code.";

--- a/iosApp/iosApp/screens/home/HomeView.swift
+++ b/iosApp/iosApp/screens/home/HomeView.swift
@@ -29,6 +29,13 @@ struct HomeView: View {
                     Label("screenPartners", systemImage: "hands.clap")
                 }
 
+            if viewModel.hasQuiz {
+                QuizVM(viewModel: viewModelFactory.makeQuizViewModel())
+                    .tabItem {
+                        Label("screenQuiz", systemImage: "questionmark.circle")
+                    }
+            }
+
             EventVM(viewModel: self.viewModelFactory.makeEventViewModel(),onDisconnectedClicked: self.onDisconnectedClicked)
                 .tabItem {
                     Label("screenEvent", systemImage: "ticket")

--- a/iosApp/iosApp/screens/home/HomeViewModel.swift
+++ b/iosApp/iosApp/screens/home/HomeViewModel.swift
@@ -18,6 +18,7 @@ class HomeViewModel: ObservableObject {
     private var featureFlagsTask: Task<(), Never>?
 
     @Published var hasNetworking: Bool = false
+    @Published var hasQuiz: Bool = false
 
     func fetchAgenda() {
         task = Task {
@@ -34,6 +35,7 @@ class HomeViewModel: ObservableObject {
                 let stream = asyncSequence(for: interactor.featureFlags())
                 for try await flags in stream {
                     self.hasNetworking = flags.hasNetworking
+                    self.hasQuiz = flags.hasQuiz
                 }
             } catch {
                 print("Failed to fetch feature flags: \(error)")

--- a/iosApp/iosApp/screens/quiz/QuizScreens.swift
+++ b/iosApp/iosApp/screens/quiz/QuizScreens.swift
@@ -1,0 +1,207 @@
+//
+//  QuizScreens.swift
+//  iosApp
+//
+//  Copyright © 2026 orgName. All rights reserved.
+//
+
+import SwiftUI
+import SharedDi
+
+struct QuizVM: View {
+    @ObservedObject var viewModel: QuizViewModel
+
+    init(viewModel: QuizViewModel) {
+        self.viewModel = viewModel
+    }
+
+    var body: some View {
+        NavigationView {
+            Group {
+                switch viewModel.step {
+                case let .code(username, score):
+                    QuizCodeView(
+                        username: username,
+                        score: score,
+                        onStart: { code, name in
+                            viewModel.startQuiz(code: code, name: name)
+                        }
+                    )
+                case .loadingQuestions, .submitting:
+                    Text("textLoading")
+                case let .questions(questions, selections):
+                    QuizQuestionsView(
+                        questions: questions,
+                        selections: selections,
+                        onSelect: { questionId, answerId in
+                            viewModel.select(questionId: questionId, answerId: answerId)
+                        },
+                        onSubmit: {
+                            viewModel.submit()
+                        }
+                    )
+                case let .result(result, labels):
+                    QuizResultView(
+                        result: result,
+                        labels: labels,
+                        onDone: {
+                            viewModel.reset()
+                        }
+                    )
+                case .alreadyCompleted:
+                    VStack(spacing: 16) {
+                        Text("quizAlreadyCompleted")
+                        Button("quizActionBackToCode") {
+                            viewModel.reset()
+                        }
+                    }
+                    .padding()
+                case let .error(message):
+                    VStack(spacing: 16) {
+                        Text(message)
+                        Button("quizActionBackToCode") {
+                            viewModel.reset()
+                        }
+                    }
+                    .padding()
+                }
+            }
+            .navigationTitle("screenQuiz")
+        }
+        .onAppear {
+            viewModel.start()
+        }
+        .onDisappear {
+            viewModel.stop()
+        }
+    }
+}
+
+struct QuizCodeView: View {
+    let username: String?
+    let score: Int?
+    let onStart: (String, String?) -> Void
+
+    @State private var code: String = ""
+    @State private var name: String = ""
+
+    private var needsName: Bool {
+        username == nil
+    }
+
+    private var canStart: Bool {
+        !code.isEmpty && (!needsName || !name.isEmpty)
+    }
+
+    var body: some View {
+        Form {
+            if let score = score {
+                Section {
+                    TagView(
+                        text: String(format: NSLocalizedString("quizScoreLabel", comment: ""), score),
+                        icon: "star.fill"
+                    )
+                }
+            }
+            Section {
+                Text("quizEnterCodeTitle")
+                    .foregroundColor(.secondary)
+                    .font(.caption)
+                TextField("quizCodeLabel", text: $code)
+                    .autocapitalization(.none)
+                if needsName {
+                    TextField("quizNameLabel", text: $name)
+                }
+            }
+            Section {
+                Button("quizActionStart") {
+                    UIApplication.shared.endEditing()
+                    onStart(code, username ?? name)
+                }
+                .disabled(!canStart)
+            }
+        }
+    }
+}
+
+struct QuizQuestionsView: View {
+    let questions: [QuizQuestion]
+    let selections: [String: String]
+    let onSelect: (String, String) -> Void
+    let onSubmit: () -> Void
+
+    private var allAnswered: Bool {
+        questions.allSatisfy { selections[$0.id] != nil }
+    }
+
+    var body: some View {
+        Form {
+            ForEach(questions, id: \.id) { question in
+                Section(header: Text(question.question)) {
+                    ForEach(question.options, id: \.id) { option in
+                        let isSelected = selections[question.id] == option.id
+                        Button {
+                            onSelect(question.id, option.id)
+                        } label: {
+                            HStack {
+                                Image(systemName: isSelected ? "largecircle.fill.circle" : "circle")
+                                    .foregroundColor(isSelected ? Color.c4hPrimary : .secondary)
+                                Text(option.label)
+                                    .foregroundColor(Color.c4hOnBackground)
+                                Spacer()
+                            }
+                        }
+                    }
+                }
+            }
+            Section {
+                Button("quizActionSubmit") {
+                    onSubmit()
+                }
+                .disabled(!allAnswered)
+            }
+        }
+    }
+}
+
+struct QuizResultView: View {
+    let result: QuizSubmissionResult
+    let labels: [String: String]
+    let onDone: () -> Void
+
+    private var scoreText: String {
+        String(
+            format: NSLocalizedString("quizResultScore", comment: ""),
+            Int(result.correctCount),
+            Int(result.totalCount)
+        )
+    }
+
+    var body: some View {
+        Form {
+            Section {
+                HStack {
+                    Spacer()
+                    TagView(
+                        text: scoreText,
+                        icon: "checkmark.seal.fill"
+                    )
+                    Spacer()
+                }
+            }
+            Section {
+                ForEach(result.perQuestion, id: \.questionId) { answered in
+                    HStack(alignment: .top) {
+                        Image(systemName: answered.isCorrect ? "checkmark.circle.fill" : "xmark.circle.fill")
+                            .foregroundColor(answered.isCorrect ? Color.c4hPrimary : .red)
+                        Text(labels[answered.questionId] ?? "")
+                            .foregroundColor(Color.c4hOnBackground)
+                    }
+                }
+            }
+            Section {
+                Button("quizActionBackToCode", action: onDone)
+            }
+        }
+    }
+}

--- a/iosApp/iosApp/screens/quiz/QuizScreens.swift
+++ b/iosApp/iosApp/screens/quiz/QuizScreens.swift
@@ -116,7 +116,7 @@ struct QuizCodeView: View {
             Section {
                 Button("quizActionStart") {
                     UIApplication.shared.endEditing()
-                    onStart(code, username ?? name)
+                    onStart(code, username == nil ? name : nil)
                 }
                 .disabled(!canStart)
             }

--- a/iosApp/iosApp/screens/quiz/QuizViewModel.swift
+++ b/iosApp/iosApp/screens/quiz/QuizViewModel.swift
@@ -1,0 +1,126 @@
+//
+//  QuizViewModel.swift
+//  iosApp
+//
+//  Copyright © 2026 orgName. All rights reserved.
+//
+
+import Foundation
+import SharedDi
+import KMPNativeCoroutinesAsync
+
+enum QuizStep {
+    case code(username: String?, score: Int?)
+    case loadingQuestions
+    case questions(questions: [QuizQuestion], selections: [String: String])
+    case submitting
+    case result(result: QuizSubmissionResult, labels: [String: String])
+    case alreadyCompleted
+    case error(String)
+}
+
+@MainActor
+class QuizViewModel: ObservableObject {
+    private let interactor: QuizInteractor = InteractorHelper().quizInteractor
+
+    @Published var step: QuizStep = .code(username: nil, score: nil)
+
+    private var currentCode: String = ""
+    private var loadedQuestions: [QuizQuestion] = []
+    private var tasks: [Task<(), Never>] = []
+
+    func start() {
+        // Observe stored username so the name prompt is skipped once registered.
+        tasks.append(Task {
+            do {
+                let stream = asyncSequence(for: interactor.storedUsername())
+                for try await name in stream {
+                    if case let .code(_, score) = self.step {
+                        self.step = .code(username: name as String?, score: score)
+                    }
+                }
+            } catch {
+                // ignore: username is optional
+            }
+        })
+        // Load cumulative score (value-returning suspend -> asyncFunction).
+        tasks.append(Task {
+            do {
+                let score = try await asyncFunction(for: interactor.cumulativeScore())
+                if case let .code(username, _) = self.step {
+                    self.step = .code(username: username, score: score.map { Int(truncating: $0) })
+                }
+            } catch {
+                // ignore: score is optional display
+            }
+        })
+    }
+
+    func startQuiz(code: String, name: String?) {
+        currentCode = code
+        if let name = name, !name.isEmpty {
+            tasks.append(Task { _ = await asyncError(for: interactor.register(username: name)) })
+        }
+        loadQuestions(code: code)
+    }
+
+    func loadQuestions(code: String) {
+        currentCode = code
+        step = .loadingQuestions
+        tasks.append(Task {
+            do {
+                let questions = try await asyncFunction(for: interactor.questions(code: code))
+                self.loadedQuestions = questions
+                self.step = .questions(questions: questions, selections: [:])
+            } catch {
+                self.step = .error(NSLocalizedString("quizErrorCodeNotFound", comment: ""))
+            }
+        })
+    }
+
+    func select(questionId: String, answerId: String) {
+        guard case let .questions(questions, selections) = step else { return }
+        var updated = selections
+        updated[questionId] = answerId
+        step = .questions(questions: questions, selections: updated)
+    }
+
+    func submit() {
+        guard case let .questions(_, selections) = step else { return }
+        let answers = selections.map { QuizAnswerInput(questionId: $0.key, answerId: $0.value) }
+        step = .submitting
+        tasks.append(Task {
+            do {
+                let result = try await asyncFunction(
+                    for: interactor.submit(code: currentCode, answers: answers)
+                )
+                self.step = .result(result: result, labels: self.buildLabels())
+            } catch {
+                // AlreadySubmitted -> show saved result if present, else alreadyCompleted.
+                if let saved = self.interactor.savedResult(code: self.currentCode) {
+                    self.step = .result(result: saved, labels: self.buildLabels())
+                } else {
+                    self.step = .alreadyCompleted
+                }
+            }
+        })
+    }
+
+    private func buildLabels() -> [String: String] {
+        var labels: [String: String] = [:]
+        for question in loadedQuestions {
+            labels[question.id] = question.question
+        }
+        return labels
+    }
+
+    func reset() {
+        step = .code(username: nil, score: nil)
+        start()
+    }
+
+    func stop() {
+        tasks.forEach { $0.cancel() }
+        tasks = []
+    }
+}

--- a/iosApp/iosApp/screens/quiz/QuizViewModel.swift
+++ b/iosApp/iosApp/screens/quiz/QuizViewModel.swift
@@ -115,6 +115,7 @@ class QuizViewModel: ObservableObject {
     }
 
     func reset() {
+        stop()
         step = .code(username: nil, score: nil)
         start()
     }

--- a/shared/core-di/src/iosMain/kotlin/com/paligot/confily/core/di/Helper.kt
+++ b/shared/core-di/src/iosMain/kotlin/com/paligot/confily/core/di/Helper.kt
@@ -7,6 +7,7 @@ import com.paligot.confily.core.networking.UserInteractor
 import com.paligot.confily.core.networking.UserRepository
 import com.paligot.confily.core.partners.PartnerInteractor
 import com.paligot.confily.core.partners.PartnerRepository
+import com.paligot.confily.core.quiz.QuizInteractor
 import com.paligot.confily.core.quiz.QuizRepository
 import com.paligot.confily.core.schedules.SessionRepository
 import com.paligot.confily.core.sessions.SessionInteractor
@@ -46,6 +47,7 @@ class InteractorHelper : KoinComponent {
     val partnerInteractor: PartnerInteractor by inject()
     val userInteractor: UserInteractor by inject()
     val mapInteractor: MapInteractor by inject()
+    val quizInteractor: QuizInteractor by inject()
 }
 
 val interactorsModule = module {
@@ -55,6 +57,7 @@ val interactorsModule = module {
     single { PartnerInteractor(get()) }
     single { UserInteractor(get()) }
     single { MapInteractor(get()) }
+    single { QuizInteractor(get()) }
 }
 
 fun initKoin() {

--- a/shared/core/src/iosMain/kotlin/com/paligot/confily/core/quiz/QuizInteractor.kt
+++ b/shared/core/src/iosMain/kotlin/com/paligot/confily/core/quiz/QuizInteractor.kt
@@ -1,0 +1,27 @@
+package com.paligot.confily.core.quiz
+
+import com.paligot.confily.models.QuizQuestion
+import com.paligot.confily.models.QuizSubmissionResult
+import com.paligot.confily.models.inputs.QuizAnswerInput
+import com.rickclephas.kmp.nativecoroutines.NativeCoroutines
+import kotlinx.coroutines.flow.Flow
+
+class QuizInteractor(private val repository: QuizRepository) {
+    @NativeCoroutines
+    suspend fun register(username: String): Unit = repository.register(username)
+
+    @NativeCoroutines
+    fun storedUsername(): Flow<String?> = repository.storedUsername()
+
+    @NativeCoroutines
+    suspend fun questions(code: String): List<QuizQuestion> = repository.questions(code)
+
+    @NativeCoroutines
+    suspend fun submit(code: String, answers: List<QuizAnswerInput>): QuizSubmissionResult =
+        repository.submit(code, answers)
+
+    fun savedResult(code: String): QuizSubmissionResult? = repository.savedResult(code)
+
+    @NativeCoroutines
+    suspend fun cumulativeScore(): Int? = repository.cumulativeScore()
+}


### PR DESCRIPTION
## Summary
Final part (4 of 4) of the Quiz frontend feature. Adds the **iOS (SwiftUI) Quiz UI** on top of the shared core (#184), the `hasQuiz` flag (#185), and the Android UI (#186) — completing the feature on both platforms.

- **`QuizInteractor`** (shared `iosMain`) wrapping `QuizRepository` with `@NativeCoroutines`, wired into `InteractorHelper`/`interactorsModule`. Bridged from Swift via `asyncSequence` (the `storedUsername` Flow), `asyncFunction(for:)` (the value-returning suspends `questions`/`submit`/`cumulativeScore`), `asyncError` (fire-and-forget `register`), and a direct synchronous call (`savedResult`).
- **`QuizViewModel`** (`@MainActor ObservableObject`) — a `QuizStep` state machine; cancels its tasks on reset/disappear.
- **Three SwiftUI screens** in `QuizScreens.swift`: code entry (prompts a name once, registers new users only), single-select questions with submit-when-all-answered, and a result screen (aggregate score + per-question correct/incorrect feedback). Shows the cumulative score on the code screen. Revisiting a completed quiz shows the saved result or an "already completed" state.
- **Quiz tab** in `HomeView`, gated on `HomeViewModel.hasQuiz` (from `flags.hasQuiz`), with `ViewModelFactory.makeQuizViewModel()`.
- Reuses iOS design tokens (`Color.c4h*`, `TagView`) and adds 11 localized strings (en + fr). New Swift files registered in the Xcode project via the `xcodeproj` tooling.

## Scope
Part 4 of 4 (iOS UI). No Android or backend changes.

## Stacking
Stacked on #186 (Android UI) — base branch `feat/quiz-android-ui`. Auto-retargets as the stack merges.

## Test Plan
- [x] `./gradlew :shared:core:compileKotlinIosSimulatorArm64 :shared:core-di:compileKotlinIosSimulatorArm64` + ktlint — clean (the `QuizInteractor` bridges)
- [x] `xcodebuild -scheme iosApp -sdk iphonesimulator ... ARCHS=arm64 ONLY_ACTIVE_ARCH=YES build` — ** BUILD SUCCEEDED **
- [x] App launches on the iOS simulator without crashing
- [ ] Visual walkthrough of the quiz flow requires a backend event with `hasQuiz=true` (not seedable locally)

> **Build note for reviewers:** the KMP simulator framework is arm64-only, so building for the simulator on an Apple-Silicon host needs `ARCHS=arm64 ONLY_ACTIVE_ARCH=YES` (or an arm64 simulator destination). A fresh checkout must also run `iosApp/Scripts/generate_config.sh` once before the first `xcodebuild`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)