### PR TITLE
fix(schedules): open OpenFeedback at session start in event timezone

### DIFF
--- a/shared/core/src/commonMain/kotlin/com/paligot/confily/core/schedules/entities/Session.kt
+++ b/shared/core/src/commonMain/kotlin/com/paligot/confily/core/schedules/entities/Session.kt
@@ -33,10 +33,15 @@ class Session(
     val feedback: FeedbackConfig?
 )
 
-fun Session.mapToSessionUi(strings: Strings, openFeedbackEnabled: Boolean = true): SessionUi {
-    val now = Clock.System.now().toLocalDateTime(TimeZone.UTC)
-    val diff = endTime.toInstant(TimeZone.UTC)
-        .minus(startTime.toInstant(TimeZone.UTC))
+fun Session.mapToSessionUi(
+    strings: Strings,
+    openFeedbackEnabled: Boolean = true,
+    clock: Clock = Clock.System,
+    timeZone: TimeZone = TimeZone.currentSystemDefault()
+): SessionUi {
+    val now = clock.now().toLocalDateTime(timeZone)
+    val diff = endTime.toInstant(timeZone)
+        .minus(startTime.toInstant(timeZone))
     return SessionUi(
         info = SessionInfoUi(
             title = title,

--- a/shared/core/src/commonTest/kotlin/com/paligot/confily/core/schedules/entities/SessionTest.kt
+++ b/shared/core/src/commonTest/kotlin/com/paligot/confily/core/schedules/entities/SessionTest.kt
@@ -1,0 +1,99 @@
+package com.paligot.confily.core.schedules.entities
+
+import com.paligot.confily.resources.EnStrings
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toInstant
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+private class FixedClock(private val instant: Instant) : Clock {
+    override fun now(): Instant = instant
+}
+
+private val parisTimeZone = TimeZone.of("Europe/Paris")
+
+private fun clockAtParisLocalTime(localTime: LocalDateTime): Clock =
+    FixedClock(localTime.toInstant(parisTimeZone))
+
+private fun session(
+    startTime: LocalDateTime,
+    endTime: LocalDateTime,
+    feedback: FeedbackConfig? = FeedbackConfig(projectId = "p", sessionId = "s", url = "https://example.com")
+) = Session(
+    id = "1",
+    title = "A talk",
+    abstract = "Abstract",
+    category = Category(id = "cat", name = "Category", color = "#ffffff", icon = null),
+    format = Format(id = "fmt", name = "Talk", time = 30),
+    tags = emptyList(),
+    room = "Hall exposant",
+    level = null,
+    language = null,
+    startTime = startTime,
+    endTime = endTime,
+    speakers = emptyList(),
+    feedback = feedback
+)
+
+class SessionTest {
+    @Test
+    fun feedbackOpensRightAfterLocalStartTimeInEventTimeZone() {
+        // Session starts at 08:30 Europe/Paris (CEST = UTC+2, i.e. 06:30 UTC).
+        val start = LocalDateTime(2026, 6, 11, 8, 30)
+        val end = LocalDateTime(2026, 6, 11, 9, 0)
+        // "Now" is one minute after the local start: 08:31 Paris = 06:31 UTC.
+        val now = clockAtParisLocalTime(LocalDateTime(2026, 6, 11, 8, 31))
+
+        val ui = session(start, end).mapToSessionUi(
+            strings = EnStrings,
+            clock = now,
+            timeZone = parisTimeZone
+        )
+
+        assertTrue(
+            ui.canGiveFeedback,
+            "Feedback must open as soon as the session has started in the event time zone"
+        )
+    }
+
+    @Test
+    fun feedbackStaysClosedBeforeLocalStartTime() {
+        val start = LocalDateTime(2026, 6, 11, 8, 30)
+        val end = LocalDateTime(2026, 6, 11, 9, 0)
+        // "Now" is one minute before the local start: 08:29 Paris.
+        val now = clockAtParisLocalTime(LocalDateTime(2026, 6, 11, 8, 29))
+
+        val ui = session(start, end).mapToSessionUi(
+            strings = EnStrings,
+            clock = now,
+            timeZone = parisTimeZone
+        )
+
+        assertFalse(
+            ui.canGiveFeedback,
+            "Feedback must stay closed until the session has started"
+        )
+    }
+
+    @Test
+    fun feedbackStaysClosedWhenSessionHasNoFeedbackConfig() {
+        val start = LocalDateTime(2026, 6, 11, 8, 30)
+        val end = LocalDateTime(2026, 6, 11, 9, 0)
+        val now = clockAtParisLocalTime(LocalDateTime(2026, 6, 11, 8, 31))
+
+        val ui = session(start, end, feedback = null).mapToSessionUi(
+            strings = EnStrings,
+            clock = now,
+            timeZone = parisTimeZone
+        )
+
+        assertFalse(
+            ui.canGiveFeedback,
+            "Feedback cannot be given when the session has no feedback configuration"
+        )
+    }
+}


### PR DESCRIPTION
## Problem
OpenFeedback was displayed ~2 hours after a session actually started for events in CEST (Europe/Paris). It should appear as soon as the session begins.

## Root cause
`Session.mapToSessionUi` computed the current time in UTC:

```kotlin
val now = Clock.System.now().toLocalDateTime(TimeZone.UTC)
...
canGiveFeedback = now > startTime && feedback != null
```

But `startTime` is a naive `LocalDateTime` holding the **event-local** wall-clock time (Europe/Paris). Comparing a UTC `now` against a Paris-local `startTime` means the gate only flips once UTC wall-clock passes the local start time — i.e. `offset` hours late (2h in summer). The agenda list was already correct because `Sessions.kt` uses `TimeZone.currentSystemDefault()`.

## Fix
- Compute `now` in the event timezone, defaulting to `TimeZone.currentSystemDefault()` (matching `Sessions.kt`).
- Add injectable `clock` / `timeZone` parameters (defaulted) so the behaviour is deterministically testable. Both existing callers are source-compatible.

## Tests
Added `SessionTest` with a deterministic regression test pinning "now" to 06:31 UTC = 08:31 Europe/Paris for an 08:30 session (fails on the old UTC code, passes now), plus before-start and no-feedback-config cases.

## Verification
- `:shared:core:desktopTest` ✅
- `ktlintCheck` + `detekt` ✅
- Dependent module `:features:schedules:schedules-presentation` compiles ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
