### PR TITLE
fix(schedule): preserve scroll position when returning from a session

### DIFF
--- a/features/schedules/schedules-panes/build.gradle.kts
+++ b/features/schedules/schedules-panes/build.gradle.kts
@@ -19,6 +19,7 @@ kotlin {
                 implementation(projects.style.speakers)
                 implementation(projects.style.theme)
 
+                implementation(compose.runtimeSaveable)
                 implementation(compose.components.resources)
             }
         }

--- a/features/schedules/schedules-panes/src/commonMain/kotlin/com/paligot/confily/schedules/panes/ScheduleGridPager.kt
+++ b/features/schedules/schedules-panes/src/commonMain/kotlin/com/paligot/confily/schedules/panes/ScheduleGridPager.kt
@@ -13,6 +13,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.listSaver
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.paligot.confily.navigation.ActionIds
@@ -50,7 +52,26 @@ fun ScheduleGridPager(
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
     val notTodayMessage = stringResource(Resource.string.text_now_not_today)
-    val gridStates = remember(agendas.size) {
+    // Persist each day's scroll position so it survives the screen leaving
+    // composition (e.g. navigating to a session detail and back).
+    val gridStates = rememberSaveable(
+        agendas.size,
+        saver = listSaver<List<LazyGridState>, Int>(
+            save = { states ->
+                states.flatMap {
+                    listOf(it.firstVisibleItemIndex, it.firstVisibleItemScrollOffset)
+                }
+            },
+            restore = { saved ->
+                val restored = saved.chunked(2).map { (index, offset) ->
+                    LazyGridState(index, offset)
+                }
+                // Always match the current page count so indexing by page is safe,
+                // even if the number of days changed while away from the screen.
+                List(agendas.size) { restored.getOrNull(it) ?: LazyGridState() }
+            }
+        )
+    ) {
         List(agendas.size) { LazyGridState() }
     }
     LaunchedEffect(key1 = Unit) {


### PR DESCRIPTION
## Problem

In the Android app's schedule screen, scrolling through the agenda, opening a session, and pressing back **reset the scroll position to the top**. The selected day was kept, but the scroll within the day was lost — forcing the user to scroll back down every time.

## Root cause

Navigation Compose only composes the top destination. When you open a session detail, the `ScheduleList` destination **leaves composition** (its `NavBackStackEntry` stays on the back stack, but the composable tree is torn down). On `popBackStack()` it's composed fresh.

The per-day scroll states in `ScheduleGridPager` were held in a plain `remember`:

```kotlin
val gridStates = remember(agendas.size) { List(agendas.size) { LazyGridState() } }
```

Plain `remember` is discarded on tear-down, so the states came back as brand-new `LazyGridState()` instances at offset 0. The pager state survived because `rememberPagerState` is saveable — which is exactly why the day was preserved but the scroll wasn't.

## Fix

Hold the grid states in `rememberSaveable` with a `listSaver` that persists each day's `firstVisibleItemIndex` + `firstVisibleItemScrollOffset`, plugging into the same `SaveableStateHolder` mechanism the back-stack entry uses. Saving the whole list under a single key avoids the per-iteration key-collision trap you'd hit building a list of `rememberLazyGridState()` calls in a loop.

The restore clamps the list to the current day count, so a changed agenda day-count can't cause an `IndexOutOfBounds` on `gridStates[page]`.

Also adds the `compose.runtimeSaveable` dependency — the module previously only used the foundation wrappers, so `androidx.compose.runtime.saveable` wasn't on its compile classpath.

## Testing

- `ktlintCheck` + `detekt` ✅
- `:androidApp:lintDebug` ✅
- Compiles for common / desktop / wasmJs / android ✅
- ⚠️ Not yet manually verified on a device — the change is a textbook `remember` → `rememberSaveable` fix, but a quick manual pass (scroll → open session → back) would confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)