### PR TITLE
Fix backend↔DB sync for sessions & maps

### DIFF
--- a/shared/core-db/src/commonMain/sqldelight/com/paligot/confily/db/Category.sq
+++ b/shared/core-db/src/commonMain/sqldelight/com/paligot/confily/db/Category.sq
@@ -19,6 +19,9 @@ PRIMARY KEY (event_id, session_id, category_id)
 upsertSessionCategory:
 INSERT OR REPLACE INTO SessionCategory VALUES ?;
 
+deleteSessionCategoriesByTalks:
+DELETE FROM SessionCategory WHERE event_id == ? AND session_id IN ?;
+
 selectCategories:
 SELECT id, name, color, icon, selected
 FROM Category

--- a/shared/core-db/src/commonMain/sqldelight/com/paligot/confily/db/EventSession.sq
+++ b/shared/core-db/src/commonMain/sqldelight/com/paligot/confily/db/EventSession.sq
@@ -30,3 +30,9 @@ WHERE EventSession.event_id = ? AND EventSession.id = ?;
 
 upsertEventSession:
 INSERT OR REPLACE INTO EventSession VALUES ?;
+
+diffEventSessions:
+SELECT id FROM EventSession WHERE event_id == ? AND id NOT IN ?;
+
+deleteEventSessions:
+DELETE FROM EventSession WHERE event_id == ? AND id IN ?;

--- a/shared/core-db/src/commonMain/sqldelight/com/paligot/confily/db/Format.sq
+++ b/shared/core-db/src/commonMain/sqldelight/com/paligot/confily/db/Format.sq
@@ -18,6 +18,9 @@ PRIMARY KEY (event_id, session_id, format_id)
 upsertSessionFormat:
 INSERT OR REPLACE INTO SessionFormat VALUES ?;
 
+deleteSessionFormatsByTalks:
+DELETE FROM SessionFormat WHERE event_id == ? AND session_id IN ?;
+
 selectFormats:
 SELECT id, name, time, selected
 FROM Format

--- a/shared/core-db/src/commonMain/sqldelight/com/paligot/confily/db/Map.sq
+++ b/shared/core-db/src/commonMain/sqldelight/com/paligot/confily/db/Map.sq
@@ -72,8 +72,8 @@ FROM Shape
 WHERE event_id == ?
 ORDER BY order_;
 
-deleteShapes:
-DELETE FROM Shape WHERE event_id == ? AND map_id IN ?;
+deleteShapesByEvent:
+DELETE FROM Shape WHERE event_id == ?;
 
 insertPictogram:
 INSERT OR REPLACE INTO Pictogram(map_id, event_id, order_, name, description, x, y, type)
@@ -85,5 +85,5 @@ FROM Pictogram
 WHERE event_id == ?
 ORDER BY order_;
 
-deletePictograms:
-DELETE FROM Pictogram WHERE event_id == ? AND map_id IN ?;
+deletePictogramsByEvent:
+DELETE FROM Pictogram WHERE event_id == ?;

--- a/shared/core-db/src/commonMain/sqldelight/com/paligot/confily/db/Schedule.sq
+++ b/shared/core-db/src/commonMain/sqldelight/com/paligot/confily/db/Schedule.sq
@@ -13,3 +13,9 @@ FOREIGN KEY (event_id) REFERENCES Event(id)
 upsertSchedule:
 INSERT OR REPLACE INTO Schedule(id, order_, session_id, session_type, start_time, end_time, room, event_id)
 VALUES ?;
+
+diffSchedules:
+SELECT id FROM Schedule WHERE event_id == ? AND id NOT IN ?;
+
+deleteSchedules:
+DELETE FROM Schedule WHERE event_id == ? AND id IN ?;

--- a/shared/core-db/src/commonMain/sqldelight/com/paligot/confily/db/Session.sq
+++ b/shared/core-db/src/commonMain/sqldelight/com/paligot/confily/db/Session.sq
@@ -89,8 +89,13 @@ WHERE TalkSessionWithSpeakers.event_id = ? AND TalkSessionWithSpeakers.speaker_i
 markAsFavorite:
 UPDATE TalkSession SET is_favorite = ? WHERE id == ? AND event_id == ?;
 
-upsertTalkSession:
-INSERT OR REPLACE INTO TalkSession VALUES ?;
+upsertTalkSession {
+INSERT OR IGNORE INTO TalkSession(id, event_id, title, abstract, level, language, slide_url, replay_url, open_feedback_url, is_favorite)
+VALUES (:id, :event_id, :title, :abstract_, :level, :language, :slide_url, :replay_url, :open_feedback_url, 0);
+UPDATE TalkSession SET title = :title, abstract = :abstract_, level = :level, language = :language,
+slide_url = :slide_url, replay_url = :replay_url, open_feedback_url = :open_feedback_url, event_id = :event_id
+WHERE id = :id;
+}
 
 upsertTalkWithSpeakersSession:
 INSERT OR REPLACE INTO TalkSessionWithSpeakers(speaker_id, talk_id, event_id) VALUES ?;

--- a/shared/core-db/src/commonMain/sqldelight/com/paligot/confily/db/Session.sq
+++ b/shared/core-db/src/commonMain/sqldelight/com/paligot/confily/db/Session.sq
@@ -115,11 +115,3 @@ WHERE event_id == ? AND talk_id NOT IN ?;
 
 deleteTalkWithSpeakers:
 DELETE FROM TalkSessionWithSpeakers WHERE event_id == ? AND talk_id IN ?;
-
-diffSessions:
-SELECT id
-FROM TalkSession
-WHERE event_id == ? AND id NOT IN ?;
-
-deleteSessions:
-DELETE FROM TalkSession WHERE event_id == ? AND id IN ?;

--- a/shared/core-db/src/commonMain/sqldelight/com/paligot/confily/db/Social.sq
+++ b/shared/core-db/src/commonMain/sqldelight/com/paligot/confily/db/Social.sq
@@ -11,6 +11,9 @@ insertSocial:
 INSERT OR REPLACE INTO Social(url, type, ext_id, event_id)
 VALUES (?, ?, ?, ?);
 
+deleteSocialsByExtIds:
+DELETE FROM Social WHERE event_id == ? AND ext_id IN ?;
+
 selectSocials:
 SELECT Social.url, Social.type
 FROM Social

--- a/shared/core-db/src/commonMain/sqldelight/com/paligot/confily/db/Tag.sq
+++ b/shared/core-db/src/commonMain/sqldelight/com/paligot/confily/db/Tag.sq
@@ -17,6 +17,9 @@ PRIMARY KEY (event_id, session_id, tag_id)
 upsertSessionTag:
 INSERT OR REPLACE INTO SessionTag VALUES ?;
 
+deleteSessionTagsByTalks:
+DELETE FROM SessionTag WHERE event_id == ? AND session_id IN ?;
+
 selectTagsBySessionId:
 SELECT Tag.id, Tag.name
 FROM Tag

--- a/shared/core/build.gradle.kts
+++ b/shared/core/build.gradle.kts
@@ -116,6 +116,11 @@ kotlin {
             dependsOn(commonMain)
             dependsOn(mobileMain)
         }
+        val desktopTest by getting {
+            dependencies {
+                implementation(libs.cash.sqldelight.desktop)
+            }
+        }
     }
 
     sourceSets.all {

--- a/shared/core/src/commonMain/kotlin/com/paligot/confily/core/events/EventRepositoryImpl.kt
+++ b/shared/core/src/commonMain/kotlin/com/paligot/confily/core/events/EventRepositoryImpl.kt
@@ -53,6 +53,7 @@ internal class EventRepositoryImpl(
             sessionDao.insertAgenda(eventId, exportPlanning)
             partnerDao.insertPartners(eventId, exportPartners)
         } catch (ex: Throwable) {
+            println("fetchAndStoreAgenda failed for event '$eventId': ${ex.message}")
             ex.printStackTrace()
         }
     }

--- a/shared/core/src/desktopTest/kotlin/com/paligot/confily/core/DatabaseHarnessTest.kt
+++ b/shared/core/src/desktopTest/kotlin/com/paligot/confily/core/DatabaseHarnessTest.kt
@@ -1,0 +1,31 @@
+package com.paligot.confily.core
+
+import com.paligot.confily.core.test.inMemoryDatabase
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class DatabaseHarnessTest {
+    @Test
+    fun in_memory_database_enforces_foreign_keys() {
+        val db = inMemoryDatabase()
+        // Shape.map_id references Map(id); inserting with a missing map must fail.
+        val threw = try {
+            db.mapQueries.insertShape(
+                order_ = 0,
+                name = "x",
+                description = null,
+                type = "Room",
+                start_x = 0.0,
+                start_y = 0.0,
+                end_x = 1.0,
+                end_y = 1.0,
+                map_id = "missing-map",
+                event_id = "missing-event"
+            )
+            false
+        } catch (e: Throwable) {
+            true
+        }
+        assertTrue(threw, "Expected a foreign-key constraint violation")
+    }
+}

--- a/shared/core/src/desktopTest/kotlin/com/paligot/confily/core/maps/MapSyncTest.kt
+++ b/shared/core/src/desktopTest/kotlin/com/paligot/confily/core/maps/MapSyncTest.kt
@@ -1,0 +1,55 @@
+package com.paligot.confily.core.maps
+
+import com.paligot.confily.core.test.Fixtures
+import com.paligot.confily.core.test.inMemoryDatabase
+import com.paligot.confily.core.test.seedEvent
+import com.paligot.confily.db.ConfilyDatabase
+import kotlinx.coroutines.Dispatchers
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MapSyncTest {
+    private val eventId = "event-1"
+
+    private fun dao(db: ConfilyDatabase) =
+        MapDaoSQLDelight(db, Dispatchers.Unconfined)
+
+    @Test
+    fun shapes_and_pictograms_do_not_accumulate_across_syncs() {
+        val db = inMemoryDatabase()
+        db.seedEvent(eventId)
+        val dao = dao(db)
+        val maps = listOf(
+            Fixtures.map(
+                id = "m1",
+                shapes = listOf(Fixtures.shape(0), Fixtures.shape(1)),
+                pictograms = listOf(Fixtures.pictogram(0))
+            )
+        )
+
+        dao.insertMaps(eventId, maps)
+        dao.insertMaps(eventId, maps)
+
+        assertEquals(2, db.mapQueries.selectShapes(eventId).executeAsList().size)
+        assertEquals(1, db.mapQueries.selectPictograms(eventId).executeAsList().size)
+    }
+
+    @Test
+    fun removed_map_and_its_children_are_deleted() {
+        val db = inMemoryDatabase()
+        db.seedEvent(eventId)
+        val dao = dao(db)
+
+        dao.insertMaps(
+            eventId,
+            listOf(
+                Fixtures.map("m1", shapes = listOf(Fixtures.shape(0))),
+                Fixtures.map("m2", shapes = listOf(Fixtures.shape(0)))
+            )
+        )
+        dao.insertMaps(eventId, listOf(Fixtures.map("m1", shapes = listOf(Fixtures.shape(0)))))
+
+        assertEquals(1, db.mapQueries.selectMaps(eventId).executeAsList().size)
+        assertEquals(1, db.mapQueries.selectShapes(eventId).executeAsList().size)
+    }
+}

--- a/shared/core/src/desktopTest/kotlin/com/paligot/confily/core/schedules/SessionSyncTest.kt
+++ b/shared/core/src/desktopTest/kotlin/com/paligot/confily/core/schedules/SessionSyncTest.kt
@@ -1,0 +1,48 @@
+package com.paligot.confily.core.schedules
+
+import com.paligot.confily.core.kvalue.ConferenceSettings
+import com.paligot.confily.core.test.Fixtures
+import com.paligot.confily.core.test.inMemoryDatabase
+import com.paligot.confily.core.test.seedEvent
+import com.paligot.confily.db.ConfilyDatabase
+import com.russhwolf.settings.ExperimentalSettingsApi
+import com.russhwolf.settings.MapSettings
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class, ExperimentalSettingsApi::class)
+class SessionSyncTest {
+    private val eventId = "event-1"
+
+    private fun dao(db: ConfilyDatabase) = SessionDaoSQLDelight(
+        db = db,
+        settings = ConferenceSettings(MapSettings()).apply { insertEventId(eventId) },
+        dispatcher = Dispatchers.Unconfined
+    )
+
+    @Test
+    fun favorite_survives_a_resync() {
+        val db = inMemoryDatabase()
+        db.seedEvent(eventId)
+        val dao = dao(db)
+        val agenda = Fixtures.agenda(
+            categories = listOf(Fixtures.category("c1")),
+            formats = listOf(Fixtures.format("f1")),
+            sessions = listOf(Fixtures.talk("t1", categoryId = "c1", formatId = "f1")),
+            schedules = listOf(Fixtures.schedule("s1", sessionId = "t1"))
+        )
+
+        dao.insertAgenda(eventId, agenda)
+        db.sessionQueries.markAsFavorite(is_favorite = true, id = "t1", event_id = eventId)
+        dao.insertAgenda(eventId, agenda)
+
+        assertEquals(
+            1L,
+            db.sessionQueries.countSessionsByFavorite(event_id = eventId, is_favorite = true)
+                .executeAsOne()
+        )
+    }
+}

--- a/shared/core/src/desktopTest/kotlin/com/paligot/confily/core/schedules/SessionSyncTest.kt
+++ b/shared/core/src/desktopTest/kotlin/com/paligot/confily/core/schedules/SessionSyncTest.kt
@@ -45,4 +45,99 @@ class SessionSyncTest {
                 .executeAsOne()
         )
     }
+
+    @Test
+    fun resync_with_same_payload_does_not_duplicate_sessions() {
+        val db = inMemoryDatabase()
+        db.seedEvent(eventId)
+        val dao = dao(db)
+        val agenda = Fixtures.agenda(
+            categories = listOf(Fixtures.category("c1")),
+            formats = listOf(Fixtures.format("f1")),
+            sessions = listOf(Fixtures.talk("t1", categoryId = "c1", formatId = "f1")),
+            schedules = listOf(Fixtures.schedule("s1", sessionId = "t1"))
+        )
+
+        dao.insertAgenda(eventId, agenda)
+        dao.insertAgenda(eventId, agenda)
+
+        assertEquals(1, db.sessionQueries.selectSessions(eventId).executeAsList().size)
+    }
+
+    @Test
+    fun changing_a_sessions_category_replaces_the_old_link_without_fk_crash() {
+        val db = inMemoryDatabase()
+        db.seedEvent(eventId)
+        val dao = dao(db)
+        dao.insertAgenda(
+            eventId,
+            Fixtures.agenda(
+                categories = listOf(Fixtures.category("c1")),
+                formats = listOf(Fixtures.format("f1")),
+                sessions = listOf(Fixtures.talk("t1", categoryId = "c1", formatId = "f1")),
+                schedules = listOf(Fixtures.schedule("s1", sessionId = "t1"))
+            )
+        )
+
+        // c1 is removed from the backend; the talk now uses c2.
+        dao.insertAgenda(
+            eventId,
+            Fixtures.agenda(
+                categories = listOf(Fixtures.category("c2")),
+                formats = listOf(Fixtures.format("f1")),
+                sessions = listOf(Fixtures.talk("t1", categoryId = "c2", formatId = "f1")),
+                schedules = listOf(Fixtures.schedule("s1", sessionId = "t1"))
+            )
+        )
+
+        val rows = db.sessionQueries.selectSessions(eventId).executeAsList()
+        assertEquals(1, rows.size)
+        assertEquals("c2", rows.single().category_id)
+    }
+
+    @Test
+    fun removed_session_speaker_tag_and_schedule_are_deleted() {
+        val db = inMemoryDatabase()
+        db.seedEvent(eventId)
+        val dao = dao(db)
+        dao.insertAgenda(
+            eventId,
+            Fixtures.agenda(
+                categories = listOf(Fixtures.category("c1")),
+                formats = listOf(Fixtures.format("f1")),
+                tags = listOf(Fixtures.tag("tag1"), Fixtures.tag("tag2")),
+                speakers = listOf(Fixtures.speaker("sp1"), Fixtures.speaker("sp2")),
+                sessions = listOf(
+                    Fixtures.talk("t1", "c1", "f1", tagIds = listOf("tag1"), speakers = listOf("sp1")),
+                    Fixtures.talk("t2", "c1", "f1", tagIds = listOf("tag2"), speakers = listOf("sp2"))
+                ),
+                schedules = listOf(
+                    Fixtures.schedule("s1", "t1"),
+                    Fixtures.schedule("s2", "t2")
+                )
+            )
+        )
+
+        // Second sync keeps only t1 / tag1 / sp1.
+        dao.insertAgenda(
+            eventId,
+            Fixtures.agenda(
+                categories = listOf(Fixtures.category("c1")),
+                formats = listOf(Fixtures.format("f1")),
+                tags = listOf(Fixtures.tag("tag1")),
+                speakers = listOf(Fixtures.speaker("sp1")),
+                sessions = listOf(
+                    Fixtures.talk("t1", "c1", "f1", tagIds = listOf("tag1"), speakers = listOf("sp1"))
+                ),
+                schedules = listOf(Fixtures.schedule("s1", "t1"))
+            )
+        )
+
+        assertEquals(1, db.sessionQueries.selectSessions(eventId).executeAsList().size)
+        assertEquals(
+            emptyList(),
+            db.tagQueries.selectTags(eventId).executeAsList().map { it.id }.filter { it == "tag2" }
+        )
+        assertEquals(0, db.speakerQueries.diffSpeakers(eventId, listOf("sp1", "sp2")).executeAsList().size)
+    }
 }

--- a/shared/core/src/desktopTest/kotlin/com/paligot/confily/core/test/Fixtures.kt
+++ b/shared/core/src/desktopTest/kotlin/com/paligot/confily/core/test/Fixtures.kt
@@ -1,0 +1,118 @@
+package com.paligot.confily.core.test
+
+import com.paligot.confily.models.AgendaV4
+import com.paligot.confily.models.Category
+import com.paligot.confily.models.EventMap
+import com.paligot.confily.models.Format
+import com.paligot.confily.models.MapPictogram
+import com.paligot.confily.models.MapShape
+import com.paligot.confily.models.MappingType
+import com.paligot.confily.models.Offset
+import com.paligot.confily.models.PictogramType
+import com.paligot.confily.models.ScheduleItemV4
+import com.paligot.confily.models.Session
+import com.paligot.confily.models.Speaker
+import com.paligot.confily.models.Tag
+
+object Fixtures {
+    fun category(id: String, name: String = id) =
+        Category(id = id, name = name, color = "#FFFFFF", icon = "icon")
+
+    fun format(id: String, name: String = id) =
+        Format(id = id, name = name, time = 30)
+
+    fun tag(id: String, name: String = id) =
+        Tag(id = id, name = name)
+
+    fun speaker(id: String) = Speaker(
+        id = id,
+        displayName = "Speaker $id",
+        pronouns = null,
+        bio = "bio",
+        jobTitle = null,
+        company = null,
+        photoUrl = "https://photo/$id",
+        socials = emptyList()
+    )
+
+    fun talk(
+        id: String,
+        categoryId: String,
+        formatId: String,
+        tagIds: List<String> = emptyList(),
+        speakers: List<String> = emptyList()
+    ) = Session.Talk(
+        id = id,
+        title = "Talk $id",
+        level = null,
+        abstract = "abstract",
+        categoryId = categoryId,
+        tagIds = tagIds,
+        formatId = formatId,
+        language = "en",
+        speakers = speakers,
+        linkSlides = null,
+        linkReplay = null,
+        openFeedback = null
+    )
+
+    fun schedule(id: String, sessionId: String) = ScheduleItemV4(
+        id = id,
+        order = 0,
+        date = "2026-06-11",
+        startTime = "2026-06-11T09:00:00",
+        endTime = "2026-06-11T09:30:00",
+        room = "Room A",
+        sessionId = sessionId
+    )
+
+    fun agenda(
+        sessions: List<Session> = emptyList(),
+        schedules: List<ScheduleItemV4> = emptyList(),
+        categories: List<Category> = emptyList(),
+        formats: List<Format> = emptyList(),
+        tags: List<Tag> = emptyList(),
+        speakers: List<Speaker> = emptyList()
+    ) = AgendaV4(
+        schedules = schedules,
+        sessions = sessions,
+        formats = formats,
+        tags = tags,
+        categories = categories,
+        speakers = speakers
+    )
+
+    fun shape(order: Int = 0) = MapShape(
+        order = order,
+        name = "shape-$order",
+        description = null,
+        start = Offset(0f, 0f),
+        end = Offset(1f, 1f),
+        type = MappingType.Room
+    )
+
+    fun pictogram(order: Int = 0) = MapPictogram(
+        order = order,
+        name = "picto-$order",
+        description = null,
+        position = Offset(0f, 0f),
+        type = PictogramType.Coffee
+    )
+
+    fun map(
+        id: String,
+        shapes: List<MapShape> = emptyList(),
+        pictograms: List<MapPictogram> = emptyList()
+    ) = EventMap(
+        id = id,
+        name = "Map $id",
+        color = "#000000",
+        colorSelected = "#111111",
+        order = 0,
+        url = "https://map/$id",
+        filledUrl = null,
+        pictoSize = 24,
+        shapes = shapes,
+        pictograms = pictograms
+    )
+}

--- a/shared/core/src/desktopTest/kotlin/com/paligot/confily/core/test/TestDatabase.kt
+++ b/shared/core/src/desktopTest/kotlin/com/paligot/confily/core/test/TestDatabase.kt
@@ -1,0 +1,25 @@
+package com.paligot.confily.core.test
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import com.paligot.confily.core.db.listOfStringsAdapter
+import com.paligot.confily.db.ConfilyDatabase
+import com.paligot.confily.db.Event
+import com.paligot.confily.db.EventSession
+import com.paligot.confily.db.Partner
+
+/**
+ * Builds a fresh in-memory ConfilyDatabase with foreign-key enforcement ON,
+ * matching the production drivers (Android `setForeignKeyConstraintsEnabled(true)`,
+ * iOS `foreignKeyConstraints = true`). FK enforcement is what makes the sync
+ * cleanup-ordering bug reproducible in tests. Adapters mirror `DatabaseWrapper`.
+ */
+fun inMemoryDatabase(): ConfilyDatabase {
+    val driver = JdbcSqliteDriver(url = JdbcSqliteDriver.IN_MEMORY, schema = ConfilyDatabase.Schema)
+    driver.execute(null, "PRAGMA foreign_keys=ON;", 0)
+    return ConfilyDatabase(
+        driver = driver,
+        EventAdapter = Event.Adapter(formatted_addressAdapter = listOfStringsAdapter),
+        EventSessionAdapter = EventSession.Adapter(formatted_addressAdapter = listOfStringsAdapter),
+        PartnerAdapter = Partner.Adapter(formatted_addressAdapter = listOfStringsAdapter)
+    )
+}

--- a/shared/core/src/desktopTest/kotlin/com/paligot/confily/core/test/TestDatabase.kt
+++ b/shared/core/src/desktopTest/kotlin/com/paligot/confily/core/test/TestDatabase.kt
@@ -23,3 +23,29 @@ fun inMemoryDatabase(): ConfilyDatabase {
         PartnerAdapter = Partner.Adapter(formatted_addressAdapter = listOfStringsAdapter)
     )
 }
+
+/**
+ * Seeds the parent Event row. Every event-scoped table (Map, TalkSession, Category…)
+ * has `FOREIGN KEY (event_id) REFERENCES Event(id)`, so the event must exist before
+ * inserting maps or an agenda — production does this via `insertEvent` first.
+ */
+fun ConfilyDatabase.seedEvent(eventId: String) {
+    eventQueries.insertEvent(
+        id = eventId,
+        name = "Test Event",
+        formatted_address = emptyList(),
+        address = "address",
+        latitude = 0.0,
+        longitude = 0.0,
+        date = "2026-06-11",
+        start_date = "2026-06-11",
+        end_date = "2026-06-12",
+        coc = null,
+        openfeedback_project_id = null,
+        contact_email = null,
+        contact_phone = null,
+        faq_url = null,
+        coc_url = null,
+        updated_at = 0L
+    )
+}

--- a/shared/core/src/mobileMain/kotlin/com/paligot/confily/core/agenda/NetMappers.kt
+++ b/shared/core/src/mobileMain/kotlin/com/paligot/confily/core/agenda/NetMappers.kt
@@ -3,7 +3,6 @@ package com.paligot.confily.core.agenda
 import com.paligot.confily.db.Event
 import com.paligot.confily.db.EventSession
 import com.paligot.confily.db.Schedule
-import com.paligot.confily.db.TalkSession
 import com.paligot.confily.db.TalkSessionWithSpeakers
 import com.paligot.confily.models.Category
 import com.paligot.confily.models.EventV5
@@ -72,19 +71,6 @@ fun <T : Session> ScheduleItemV4.convertToDb(eventId: String, type: KClass<T>): 
         session_type = if (type == Session.Talk::class) "Talk" else "Event",
         event_id = eventId
     )
-
-fun Session.Talk.convertToDb(eventId: String): TalkSession = TalkSession(
-    id = this.id,
-    title = this.title,
-    level = this.level,
-    abstract_ = this.abstract,
-    language = this.language,
-    slide_url = this.linkSlides,
-    replay_url = this.linkReplay,
-    open_feedback_url = this.openFeedback,
-    event_id = eventId,
-    is_favorite = false
-)
 
 fun Session.Talk.convertToDb(eventId: String, speakerId: String) = TalkSessionWithSpeakers(
     id = 0L,

--- a/shared/core/src/mobileMain/kotlin/com/paligot/confily/core/maps/MapDaoSQLDelight.kt
+++ b/shared/core/src/mobileMain/kotlin/com/paligot/confily/core/maps/MapDaoSQLDelight.kt
@@ -33,6 +33,10 @@ class MapDaoSQLDelight(
             .map { it.map(SelectFilledMaps::mapToEntity) }
 
     override fun insertMaps(eventId: String, maps: List<EventMap>) = db.transaction {
+        // Shapes/pictograms have autoincrement PKs (no backend id), so they can't be
+        // upserted. Clear them for the event, then rebuild from the response.
+        db.mapQueries.deleteShapesByEvent(event_id = eventId)
+        db.mapQueries.deletePictogramsByEvent(event_id = eventId)
         maps.forEach { map ->
             db.mapQueries.insertMap(
                 id = map.id,
@@ -74,8 +78,6 @@ class MapDaoSQLDelight(
         }
         val diff = db.mapQueries.diffMaps(event_id = eventId, id = maps.map { it.id })
             .executeAsList()
-        db.mapQueries.deleteShapes(event_id = eventId, map_id = diff)
-        db.mapQueries.deletePictograms(event_id = eventId, map_id = diff)
         db.mapQueries.deleteMaps(event_id = eventId, id = diff)
     }
 }

--- a/shared/core/src/mobileMain/kotlin/com/paligot/confily/core/schedules/SessionDaoSQLDelight.kt
+++ b/shared/core/src/mobileMain/kotlin/com/paligot/confily/core/schedules/SessionDaoSQLDelight.kt
@@ -281,7 +281,17 @@ class SessionDaoSQLDelight(
         agenda.sessions.forEach { session ->
             when (session) {
                 is com.paligot.confily.models.Session.Talk -> {
-                    db.sessionQueries.upsertTalkSession(session.convertToDb(eventId))
+                    db.sessionQueries.upsertTalkSession(
+                        id = session.id,
+                        event_id = eventId,
+                        title = session.title,
+                        abstract_ = session.abstract,
+                        level = session.level,
+                        language = session.language,
+                        slide_url = session.linkSlides,
+                        replay_url = session.linkReplay,
+                        open_feedback_url = session.openFeedback
+                    )
                     db.categoryQueries.upsertSessionCategory(
                         SessionCategory(
                             event_id = eventId,

--- a/shared/core/src/mobileMain/kotlin/com/paligot/confily/core/schedules/SessionDaoSQLDelight.kt
+++ b/shared/core/src/mobileMain/kotlin/com/paligot/confily/core/schedules/SessionDaoSQLDelight.kt
@@ -248,8 +248,10 @@ class SessionDaoSQLDelight(
         }
 
     override fun insertAgenda(eventId: String, agenda: AgendaV4) = db.transaction {
+        val sessionIds = agenda.sessions.map { it.id }
         agenda.speakers.forEach { speaker ->
             db.speakerQueries.upsertSpeaker(speaker.convertToDb(eventId))
+            db.socialQueries.deleteSocialsByExtIds(event_id = eventId, ext_id = listOf(speaker.id))
             speaker.socials.forEach {
                 db.socialQueries.insertSocial(it.url, it.type.name.lowercase(), speaker.id, eventId)
             }
@@ -278,6 +280,13 @@ class SessionDaoSQLDelight(
                 event_id = eventId
             )
         }
+        // Rebuild junction/speaker links for the sessions in this response: clear them
+        // first, then re-insert below. A changed category/format/tag/speaker set then
+        // replaces the old one instead of leaving stale rows behind.
+        db.categoryQueries.deleteSessionCategoriesByTalks(event_id = eventId, session_id = sessionIds)
+        db.formatQueries.deleteSessionFormatsByTalks(event_id = eventId, session_id = sessionIds)
+        db.tagQueries.deleteSessionTagsByTalks(event_id = eventId, session_id = sessionIds)
+        db.sessionQueries.deleteTalkWithSpeakers(event_id = eventId, talk_id = sessionIds)
         agenda.sessions.forEach { session ->
             when (session) {
                 is com.paligot.confily.models.Session.Talk -> {
@@ -346,30 +355,44 @@ class SessionDaoSQLDelight(
     }
 
     private fun clean(eventId: String, agenda: AgendaV4) = db.transaction {
-        val diffSpeakers = db.speakerQueries
+        val sessionIds = agenda.sessions.map { it.id }
+        val removedTalks = db.sessionQueries
+            .diffTalkSessions(event_id = eventId, id = sessionIds)
+            .executeAsList()
+        val removedEvents = db.eventSessionQueries
+            .diffEventSessions(event_id = eventId, id = sessionIds)
+            .executeAsList()
+        val removedSchedules = db.scheduleQueries
+            .diffSchedules(event_id = eventId, id = agenda.schedules.map { it.id })
+            .executeAsList()
+        val removedSpeakers = db.speakerQueries
             .diffSpeakers(event_id = eventId, id = agenda.speakers.map { it.id })
             .executeAsList()
-        db.speakerQueries.deleteSpeakers(event_id = eventId, id = diffSpeakers)
-        val diffCategories = db.categoryQueries
+        val removedCategories = db.categoryQueries
             .diffCategories(event_id = eventId, id = agenda.categories.map { it.id })
             .executeAsList()
-        db.categoryQueries.deleteCategories(event_id = eventId, id = diffCategories)
-        val diffFormats = db.formatQueries
+        val removedFormats = db.formatQueries
             .diffFormats(event_id = eventId, id = agenda.formats.map { it.id })
             .executeAsList()
-        db.formatQueries.deleteFormats(event_id = eventId, id = diffFormats)
-        val talkIds = agenda.sessions.map { it.id }
-        val diffTalkSession = db.sessionQueries
-            .diffTalkSessions(event_id = eventId, id = talkIds)
+        val removedTags = db.tagQueries
+            .diffTags(event_id = eventId, id = agenda.tags.map { it.id })
             .executeAsList()
-        db.sessionQueries.deleteTalkSessions(event_id = eventId, id = diffTalkSession)
-        val diffTalkWithSpeakers = db.sessionQueries
-            .diffTalkWithSpeakers(event_id = eventId, talk_id = talkIds)
-            .executeAsList()
-        db.sessionQueries.deleteTalkWithSpeakers(event_id = eventId, talk_id = diffTalkWithSpeakers)
-        val diffSessions = db.sessionQueries
-            .diffSessions(event_id = eventId, id = talkIds)
-            .executeAsList()
-        db.sessionQueries.deleteSessions(event_id = eventId, id = diffSessions)
+
+        // (a) Delete child/junction rows first so the parent deletes below cannot
+        // trip a foreign-key constraint (which would otherwise roll back the sync).
+        db.categoryQueries.deleteSessionCategoriesByTalks(event_id = eventId, session_id = removedTalks)
+        db.formatQueries.deleteSessionFormatsByTalks(event_id = eventId, session_id = removedTalks)
+        db.tagQueries.deleteSessionTagsByTalks(event_id = eventId, session_id = removedTalks)
+        db.sessionQueries.deleteTalkWithSpeakers(event_id = eventId, talk_id = removedTalks)
+        db.scheduleQueries.deleteSchedules(event_id = eventId, id = removedSchedules)
+        db.socialQueries.deleteSocialsByExtIds(event_id = eventId, ext_id = removedSpeakers)
+
+        // (b) Delete parents now that nothing references them.
+        db.sessionQueries.deleteTalkSessions(event_id = eventId, id = removedTalks)
+        db.eventSessionQueries.deleteEventSessions(event_id = eventId, id = removedEvents)
+        db.speakerQueries.deleteSpeakers(event_id = eventId, id = removedSpeakers)
+        db.categoryQueries.deleteCategories(event_id = eventId, id = removedCategories)
+        db.formatQueries.deleteFormats(event_id = eventId, id = removedFormats)
+        db.tagQueries.deleteTags(event_id = eventId, id = removedTags)
     }
 }


### PR DESCRIPTION
## Summary

The agenda/maps sync already used an "upsert + diff-delete" pattern, but the **delete** half was incomplete. Combined with enforced foreign keys, that produced three symptoms: stale data not removed, sync silently doing nothing, and duplicated map shapes/pictograms.

Root cause: when the backend dropped a referenced parent (category/format/tag/speaker), `clean()` deleted it while a stale junction row still pointed at it → `SQLITE_CONSTRAINT_FOREIGNKEY` → the swallowing `catch` in `fetchAndStoreAgenda` rolled back the **whole** transaction. So "stale data not removed" and "sync does nothing" were the same bug.

This PR completes the cleanup and makes deletion FK-safe:

- **Maps (M1):** clear shapes/pictograms per event before re-inserting — they have autoincrement PKs and can't be upserted, so they accumulated every sync (and the `Map` REPLACE itself tripped an FK once children existed).
- **Sessions:** rebuild `SessionCategory`/`SessionFormat`/`SessionTag` and speaker links for the response's sessions, delete child/junction rows **before** parents in `clean()`, wire up the unused `Tag` delete, add real `EventSession`/`Schedule` diff-deletes, and drop the misdirected `diffSessions`/`deleteSessions` duplicates.
- **Favorites (F1):** `TalkSession` now uses an `INSERT OR IGNORE … UPDATE` upsert (like `Category`/`Format`) so `is_favorite` survives a sync instead of being reset to `false` by `INSERT OR REPLACE`.
- **Logging (X1):** `fetchAndStoreAgenda` now logs the event id on failure (catch kept by design).
- **Tests:** new in-memory SQLDelight harness (`desktopTest`, FK enforcement on) covering duplication, idempotent re-sync, category reassignment without FK crash, favorite preservation, and removal of stale rows.

## Test Plan

- [x] `./gradlew :shared:core:desktopTest` — 20 tests, 0 failures
- [x] `./gradlew ktlintCheck detekt` — clean
- [x] `./gradlew lintDebug` — clean
- [ ] Manual: sync an event, remove a session/category on the backend, re-sync, confirm it disappears
- [ ] Manual: favorite a talk, re-sync, confirm it stays favorited

🤖 Generated with [Claude Code](https://claude.com/claude-code)